### PR TITLE
Address readability

### DIFF
--- a/packages/fether-react/src/assets/sass/components/_account.scss
+++ b/packages/fether-react/src/assets/sass/components/_account.scss
@@ -3,7 +3,7 @@
 
   &.-header {
     .account_address {
-      font-size: 0.6rem;
+      font-size: 0.7rem;
     }
   }
 

--- a/packages/fether-ui/src/AddressShort/AddressShort.js
+++ b/packages/fether-ui/src/AddressShort/AddressShort.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 
 const AddressShort = ({ address, as: T = 'span', ...otherProps }) => (
   <T {...otherProps}>
-    {address.slice(0, 4)}..{address.slice(-4)}
+    {address.slice(0, 6)}..{address.slice(-4)}
   </T>
 );
 


### PR DESCRIPTION
- Make full address a little bigger on the account screen
- Show the first 4 digits of the address on general screen (including "0x", so 6 digits)