### PR TITLE
Set `userData` folder

### DIFF
--- a/packages/fether-electron/package.json
+++ b/packages/fether-electron/package.json
@@ -1,5 +1,6 @@
 {
   "name": "fether",
+  "appName": "fether",
   "description": "Fether Wallet",
   "version": "0.1.0",
   "private": true,

--- a/packages/fether-electron/src/main/index.js
+++ b/packages/fether-electron/src/main/index.js
@@ -17,20 +17,28 @@ import addMenu from './menu';
 import cli from './cli';
 import handleError from './utils/handleError';
 import messages from './messages';
-import { parity } from '../../package.json';
+import { appName, parity } from '../../package.json';
 import Pino from './utils/pino';
 import { productName } from '../../electron-builder.json';
 import staticPath from './utils/staticPath';
 
 const { app, BrowserWindow, ipcMain, session } = electron;
 let mainWindow;
-const pino = Pino();
 
 // Disable gpu acceleration on linux
 // https://github.com/parity-js/fether/issues/85
 if (!['darwin', 'win32'].includes(process.platform)) {
   app.disableHardwareAcceleration();
 }
+
+// userData value is derived from the Electron app name by default. However,
+// Electron doesn't know the app name defined in package.json because we
+// execute Electron directly on a file. Running Electron on a folder (either
+// .build/ or electron/) doesn't solve the issue because the package.json
+// is located in a different directory.
+app.setPath('userData', path.join(app.getPath('appData'), appName));
+
+const pino = Pino();
 
 function createWindow () {
   pino.info(`Starting ${productName}...`);

--- a/packages/fether-electron/src/main/messages/index.js
+++ b/packages/fether-electron/src/main/messages/index.js
@@ -7,12 +7,16 @@ import { signerNewToken } from '@parity/electron';
 
 import Pino from '../utils/pino';
 
-const pino = Pino();
-
 /**
  * Handle all asynchronous messages from renderer to main.
  */
 export default async (mainWindow, event, action, ...args) => {
+
+  // Pino mustn't be instantiated in the body of the module (outside of the
+  // exports), or else it will be evaluated straight away and use `userData`
+  // before `userData` was set in index.js
+  const pino = Pino();
+
   try {
     if (!action) {
       return;

--- a/packages/fether-electron/src/main/utils/handleError.js
+++ b/packages/fether-electron/src/main/utils/handleError.js
@@ -8,10 +8,13 @@ import { app, dialog, shell } from 'electron';
 import { bugs, name, parity } from '../../../package.json';
 import Pino from './pino';
 
-const logFile = `${app.getPath('userData')}/${name}.log`;
-const pino = Pino();
-
 export default (err, message = 'An error occurred.') => {
+
+  // `userData` (which Pino also uses) needs to be gotten inside the exports,
+  // otherwise it is evaluated straight away, before index.js has set it
+  const logFile = `${app.getPath('userData')}/${name}.log`;
+  const pino = Pino();
+
   pino.error(err);
   dialog.showMessageBox(
     {

--- a/packages/fether-electron/src/main/utils/pino.js
+++ b/packages/fether-electron/src/main/utils/pino.js
@@ -10,26 +10,31 @@ import Pino from 'pino';
 
 import { name } from '../../../package.json';
 
-// Pino by default outputs JSON. We prettify that.
-const pretty = Pino.pretty();
-pretty.pipe(process.stdout);
+// We cannot use `app.getPath('userData')` in the body of the module (outside of
+// the exports) because then it is evaluated right away, before userData is even
+// set in index.js
+export default opts => {
+  // Pino by default outputs JSON. We prettify that.
+  const pretty = Pino.pretty();
+  pretty.pipe(process.stdout);
 
-// Create userData folder if it doesn't exist
-try {
-  fs.statSync(app.getPath('userData'));
-} catch (e) {
-  fs.mkdirSync(app.getPath('userData'));
+  // Create userData folder if it doesn't exist
+  try {
+    fs.statSync(app.getPath('userData'));
+  } catch (e) {
+    fs.mkdirSync(app.getPath('userData'));
+  }
+
+  // Create 2 output streams:
+  // - fether.log file (raw JSON)
+  // - stdout (prettified output)
+  const streams = [
+    {
+      level: 'info',
+      stream: fs.createWriteStream(`${app.getPath('userData')}/${name}.log`)
+    },
+    { level: 'info', stream: pretty }
+  ];
+
+  return Pino({ name, ...opts }, multistream(streams));
 }
-
-// Create 2 output streams:
-// - fether.log file (raw JSON)
-// - stdout (prettified output)
-const streams = [
-  {
-    level: 'info',
-    stream: fs.createWriteStream(`${app.getPath('userData')}/${name}.log`)
-  },
-  { level: 'info', stream: pretty }
-];
-
-export default opts => Pino({ name, ...opts }, multistream(streams));


### PR DESCRIPTION
Use `fether` as appName (folder name where the program's files are stored) rather than the default `Electron`.

Based on https://github.com/parity-js/shell/pull/141/