### PR TITLE
Improvements to health status

### DIFF
--- a/packages/fether-react/src/App/App.js
+++ b/packages/fether-react/src/App/App.js
@@ -73,9 +73,7 @@ class App extends Component {
         {status !== STATUS.GOOD && <Overlay />}
 
         {/* Don't display child components requiring RPCs if API is not yet set */
-          ![STATUS.DOWNLOADING, STATUS.RUNNING, STATUS.CANTCONNECT].includes(
-            status
-          ) && (
+          ![STATUS.DOWNLOADING, STATUS.LAUNCHING].includes(status) && (
             <Switch>
               {/* The next line is the homepage */}
               <Redirect exact from='/' to='/accounts' />

--- a/packages/fether-react/src/Health/Health.js
+++ b/packages/fether-react/src/Health/Health.js
@@ -33,7 +33,7 @@ class Health extends Component {
       case STATUS.GOOD:
         return '-good';
       case STATUS.DOWNLOADING:
-      case STATUS.RUNNING:
+      case STATUS.LAUNCHING:
       case STATUS.SYNCING:
         return '-syncing';
       default:
@@ -46,8 +46,6 @@ class Health extends Component {
       health: { status, payload }
     } = this.props;
     switch (status) {
-      case STATUS.CANTCONNECT:
-        return "Can't connect to Parity";
       case STATUS.CLOCKNOTSYNC:
         return 'Clock not sync';
       case STATUS.DOWNLOADING:
@@ -58,8 +56,8 @@ class Health extends Component {
         return 'No Internet connection';
       case STATUS.NOPEERS:
         return 'Not connected to any peers';
-      case STATUS.RUNNING:
-        return 'Running...';
+      case STATUS.LAUNCHING:
+        return 'Launching the node...';
       case STATUS.SYNCING:
         return `Syncing...${
           payload && payload.percentage && payload.percentage.gt(0)

--- a/packages/fether-react/src/Overlay/Overlay.js
+++ b/packages/fether-react/src/Overlay/Overlay.js
@@ -100,7 +100,7 @@ class Overlays extends Component {
         return 'No Internet connection';
       case STATUS.NOPEERS:
         return 'Bad connectivity';
-      case STATUS.RUNNING:
+      case STATUS.LAUNCHING:
         return 'Connecting to the node...';
       case STATUS.SYNCING:
         return 'Syncing...';

--- a/packages/fether-react/src/utils/withHealth.js
+++ b/packages/fether-react/src/utils/withHealth.js
@@ -113,7 +113,7 @@ const rpcs$ = isApiConnected$.pipe(
       peerCount$().pipe(withoutLoading())
     )
   ),
-  startWith([{ isSync: true }, null]), // Don't stall the HOC's combineLatest; emit immediately
+  startWith([{ isSync: false }, null]), // Don't stall the HOC's combineLatest; emit immediately
   publishReplay(1)
 );
 rpcs$.connect();

--- a/packages/fether-react/src/utils/withHealth.js
+++ b/packages/fether-react/src/utils/withHealth.js
@@ -141,9 +141,7 @@ export default compose(
               health: {
                 status: STATUS.DOWNLOADING,
                 payload: {
-                  percentage: new BigNumber(
-                    Math.round(parityStore.downloadProgress * 100)
-                  )
+                  percentage: new BigNumber(Math.round(downloadProgress * 100))
                 }
               }
             };


### PR DESCRIPTION
- Fix 'Downloading: NaN%'
- Start with 'Syncing...' if we don't know if we're synced (makes more sense to go from 'Syncing...' to 'Synced' if we were initially synced than it makes sense to go from 'Synced' to 'Syncing...' if we weren't synced initially)
- Renamed "STATUS.RUNNING" to "STATUS.LAUNCHING" to avoid ambiguity
- Fix inconsistencies in the health messages; before this PR we would have "Cannot connect to Parity" pop up out of nowhere for example. There is no way to distinguish "Cannot connect to Parity" to "Connecting to Parity" (getting a token from the signer) currently; plus isApiConnected$ is updated every second only, so this makes for a lot of inconsistencies in the health messages being shown. Now we make "Launching..." the default beginning value instead of "Cannot connect to Parity".