### PR TITLE
Use arrow instead of close icons

### DIFF
--- a/packages/fether-react/src/Send/Signer/Signer.js
+++ b/packages/fether-react/src/Send/Signer/Signer.js
@@ -52,7 +52,7 @@ class Signer extends Component {
       <div>
         <Header
           left={
-            <Link to={`/tokens/${accountAddress}`} className='icon -close'>
+            <Link to={`/tokens/${accountAddress}`} className='icon -back'>
               Close
             </Link>
           }

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -50,7 +50,7 @@ class Send extends Component {
       <div>
         <Header
           left={
-            <Link to={`/tokens/${accountAddress}`} className='icon -close'>
+            <Link to={`/tokens/${accountAddress}`} className='icon -back'>
               Close
             </Link>
           }

--- a/packages/fether-react/src/Whitelist/Whitelist.js
+++ b/packages/fether-react/src/Whitelist/Whitelist.js
@@ -102,7 +102,7 @@ class Whitelist extends Component {
       <div>
         <Header
           left={
-            <a to='/tokens' className='icon -close' onClick={history.goBack}>
+            <a to='/tokens' className='icon -back' onClick={history.goBack}>
               Close
             </a>
           }


### PR DESCRIPTION
- fix #233
- Because mobile view works the same way (only with back arrows) I've change all the ones I found.