### PR TITLE
Add gas estimation to the `postTransaction` RPC

### DIFF
--- a/packages/fether-react/package.json
+++ b/packages/fether-react/package.json
@@ -43,6 +43,7 @@
     "debug": "^3.1.0",
     "fether-ui": "^0.1.2",
     "final-form": "^4.8.3",
+    "final-form-calculate": "^1.2.1",
     "is-electron": "^2.1.0",
     "localforage": "^1.7.2",
     "localforage-observable": "^1.4.0",

--- a/packages/fether-react/src/RequireHealthOverlay/RequireHealthOverlay.js
+++ b/packages/fether-react/src/RequireHealthOverlay/RequireHealthOverlay.js
@@ -53,7 +53,7 @@ class RequireHealthOverlay extends Component {
         this.setState({ visible: true });
       }
     }
-  }
+  };
 
   render () {
     const { visible } = this.state;

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -35,8 +35,13 @@ const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 class Send extends Component {
   handleSubmit = values => {
     const { accountAddress, history, sendStore, token } = this.props;
+    console.log('values: ', values);
     sendStore.setTx(values);
     history.push(`/send/${token.address}/from/${accountAddress}/signer`);
+  };
+
+  updateGas = (value, state, { changeValue }) => {
+    changeValue(state, 'gas', value => value);
   };
 
   render () {
@@ -68,6 +73,8 @@ class Send extends Component {
                     initialValues={{ from: accountAddress, gasPrice: 4, ...tx }}
                     onSubmit={this.handleSubmit}
                     validate={this.validateForm}
+                    /** Converts a form value to uppercase **/
+                    mutators={this.updateGas}
                     render={({ handleSubmit, valid, validating, values }) => (
                       <form className='send-form' onSubmit={handleSubmit}>
                         <fieldset className='form_fields'>
@@ -106,6 +113,15 @@ class Send extends Component {
                             step={0.5}
                             type='range' // In Gwei
                           />
+
+                          <Field
+                            className='form_field_gas'
+                            name='gas'
+                            render={FetherForm.Slider}
+                            required
+                            value={values.gas}
+                          />
+
                           {values.to === values.from && (
                             <span>
                               <h3>WARNING:</h3>
@@ -155,7 +171,9 @@ class Send extends Component {
       }
 
       const estimated = await estimateGas(values, token, parityStore.api);
-
+      values.gas = estimated;
+      this.updateGas(estimated);
+      console.log('values estimated: ', values);
       if (!ethBalance || isNaN(estimated)) {
         throw new Error('No "ethBalance" or "estimated" value.');
       }
@@ -170,6 +188,7 @@ class Send extends Component {
         return { amount: "You don't have enough ETH balance" };
       }
     } catch (err) {
+      console.log(err);
       return {
         amount: 'Failed estimating balance, please try again'
       };

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -54,11 +54,11 @@ class Send extends Component {
         field: /to|amount/, // when the value of these fields change...
         updates: {
           // ...set field "gas"
-          gas: async (value, allValues) => {
+          gas: (value, allValues) => {
             const { parityStore, token } = this.props;
             if (this.preValidate(allValues, false)) {
               // this means amount has errors
-              return await estimateGas(allValues, token, parityStore.api);
+              return estimateGas(allValues, token, parityStore.api);
             } else {
               return null;
             }

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -51,7 +51,6 @@ class Send extends Component {
         if (this.preValidate(allValues) === true) {
           return estimateGas(allValues, token, parityStore.api);
         } else {
-          // this means amount has errors
           return null;
         }
       }
@@ -168,9 +167,8 @@ class Send extends Component {
       return { amount: 'Please enter a positive amount ' };
     } else if (balance && balance.lt(amount)) {
       return { amount: `You don't have enough ${token.symbol} balance` };
-    } else if (!values.to || isNaN(values.to)) {
-      // for gas estimation, the receiving address must be set
-      return false;
+    } else if (!values.to || !isAddress(values.to)) {
+      return { to: 'Please enter a valid Ethereum address' };
     }
     return true;
   };
@@ -179,7 +177,7 @@ class Send extends Component {
    * Estimate gas amount, and validate that the user has enough balance to make
    * the tx.
    */
-  validateAmount = debounce(values => {
+  validateForm = debounce(values => {
     try {
       const { ethBalance, token } = this.props;
 
@@ -209,16 +207,6 @@ class Send extends Component {
       };
     }
   }, 1000);
-
-  validateForm = values => {
-    const errors = {};
-
-    if (!isAddress(values.to)) {
-      errors.to = 'Please enter a valid Ethereum address';
-    }
-
-    return Object.keys(errors).length ? errors : this.validateAmount(values);
-  };
 }
 
 export default Send;

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -35,13 +35,8 @@ const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 class Send extends Component {
   handleSubmit = values => {
     const { accountAddress, history, sendStore, token } = this.props;
-    console.log('values: ', values);
     sendStore.setTx(values);
     history.push(`/send/${token.address}/from/${accountAddress}/signer`);
-  };
-
-  updateGas = (value, state, { changeValue }) => {
-    changeValue(state, 'gas', value => value);
   };
 
   render () {
@@ -73,8 +68,6 @@ class Send extends Component {
                     initialValues={{ from: accountAddress, gasPrice: 4, ...tx }}
                     onSubmit={this.handleSubmit}
                     validate={this.validateForm}
-                    /** Converts a form value to uppercase **/
-                    mutators={this.updateGas}
                     render={({ handleSubmit, valid, validating, values }) => (
                       <form className='send-form' onSubmit={handleSubmit}>
                         <fieldset className='form_fields'>
@@ -113,15 +106,6 @@ class Send extends Component {
                             step={0.5}
                             type='range' // In Gwei
                           />
-
-                          <Field
-                            className='form_field_gas'
-                            name='gas'
-                            render={FetherForm.Slider}
-                            required
-                            value={values.gas}
-                          />
-
                           {values.to === values.from && (
                             <span>
                               <h3>WARNING:</h3>
@@ -171,9 +155,7 @@ class Send extends Component {
       }
 
       const estimated = await estimateGas(values, token, parityStore.api);
-      values.gas = estimated;
-      this.updateGas(estimated);
-      console.log('values estimated: ', values);
+
       if (!ethBalance || isNaN(estimated)) {
         throw new Error('No "ethBalance" or "estimated" value.');
       }
@@ -188,7 +170,6 @@ class Send extends Component {
         return { amount: "You don't have enough ETH balance" };
       }
     } catch (err) {
-      console.log(err);
       return {
         amount: 'Failed estimating balance, please try again'
       };

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -161,7 +161,7 @@ class Send extends Component {
     );
   }
 
-  validateAndEstimate = async (values, withError) => {
+  validateAndEstimate = (values, withError) => {
     const { balance, parityStore, token } = this.props;
     const amount = +values.amount;
 
@@ -175,7 +175,7 @@ class Send extends Component {
         : false;
     }
 
-    return await estimateGas(values, token, parityStore.api);
+    return estimateGas(values, token, parityStore.api);
   };
 
   /**

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -173,6 +173,9 @@ class Send extends Component {
       return withError
         ? { amount: `You don't have enough ${token.symbol} balance` }
         : false;
+    } else if (!values.to || isNaN(values.to)) {
+      // for gas estimation, the receiving address must be set
+      return false;
     }
     return true;
   };

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -54,8 +54,9 @@ class Send extends Component {
         field: 'to', // when the value of these fields change...
         updates: {
           // ...set field "gas"
-          gas: async (amountValue, allValues) => {
+          gas: async (value, allValues) => {
             const estimated = await this.validateAndEstimate(allValues, false);
+            console.log('estimated: ', estimated);
             return estimated ? estimated.toString() : null;
           }
         }
@@ -125,7 +126,7 @@ class Send extends Component {
                           <div className='hidden'>
                             <Field
                               name='gas'
-                              required
+                              // required
                               render={FetherForm.Field}
                             />
                           </div>

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -33,8 +33,22 @@ const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 @withEthBalance // ETH balance
 @observer
 class Send extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      gas: 0
+    };
+    this.isUnmounted = false;
+  }
+
+  componentWillUnmount () {
+    this.isUnmounted = true;
+  }
+
   handleSubmit = values => {
     const { accountAddress, history, sendStore, token } = this.props;
+    values.gas = this.state.gas;
+
     sendStore.setTx(values);
     history.push(`/send/${token.address}/from/${accountAddress}/signer`);
   };
@@ -155,6 +169,7 @@ class Send extends Component {
       }
 
       const estimated = await estimateGas(values, token, parityStore.api);
+      !this.isUnmounted && this.setState({ gas: estimated.toString() });
 
       if (!ethBalance || isNaN(estimated)) {
         throw new Error('No "ethBalance" or "estimated" value.');

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -41,6 +41,22 @@ class Send extends Component {
     history.push(`/send/${token.address}/from/${accountAddress}/signer`);
   };
 
+  decorator = createDecorator({
+    field: /to|amount/, // when the value of these fields change...
+    updates: {
+      // ...set field "gas"
+      gas: (value, allValues) => {
+        const { parityStore, token } = this.props;
+        if (this.preValidate(allValues, false)) {
+          return estimateGas(allValues, token, parityStore.api);
+        } else {
+          // this means amount has errors
+          return null;
+        }
+      }
+    }
+  });
+
   render () {
     const {
       accountAddress,
@@ -48,24 +64,6 @@ class Send extends Component {
       token
     } = this.props;
 
-    const decorator = createDecorator(
-      // Calculations:
-      {
-        field: /to|amount/, // when the value of these fields change...
-        updates: {
-          // ...set field "gas"
-          gas: (value, allValues) => {
-            const { parityStore, token } = this.props;
-            if (this.preValidate(allValues, false)) {
-              // this means amount has errors
-              return estimateGas(allValues, token, parityStore.api);
-            } else {
-              return null;
-            }
-          }
-        }
-      }
-    );
     return (
       <div>
         <Header
@@ -88,7 +86,7 @@ class Send extends Component {
                     initialValues={{ from: accountAddress, gasPrice: 4, ...tx }}
                     onSubmit={this.handleSubmit}
                     validate={this.validateForm}
-                    decorators={[decorator]}
+                    decorators={[this.decorator]}
                     render={({ handleSubmit, valid, validating, values }) => (
                       <form className='send-form' onSubmit={handleSubmit}>
                         <fieldset className='form_fields'>

--- a/packages/fether-react/src/utils/estimateGas.js
+++ b/packages/fether-react/src/utils/estimateGas.js
@@ -12,7 +12,7 @@ import { toWei } from '@parity/api/lib/util/wei';
 import Debug from './debug';
 
 const debug = Debug('estimateGas');
-const GAS_MULT_FACTOR = 1.25; // Since estimateGas is not always accurate, we add a 33% factor for buffer.
+const GAS_MULT_FACTOR = 1.25; // Since estimateGas is not always accurate, we add a 25% factor for buffer.
 
 export const contractForToken = memoize(tokenAddress =>
   makeContract(tokenAddress, abi)
@@ -27,7 +27,12 @@ export const estimateGas = (tx, token, api) => {
   }
 
   if (token.address === 'ETH') {
-    return estimateGasForEth(txForEth(tx), api).then(addBuffer);
+    return estimateGasForEth(txForEth(tx), api).then(estimatedGasForEth => {
+      // do not add any buffer in case of an account to account transaction
+      return estimatedGasForEth.eq(21000)
+        ? estimatedGasForEth
+        : addBuffer(estimatedGasForEth);
+    });
   } else {
     return estimateGasForErc20(txForErc20(tx, token), token).then(addBuffer);
   }

--- a/packages/fether-react/src/utils/estimateGas.js
+++ b/packages/fether-react/src/utils/estimateGas.js
@@ -95,10 +95,15 @@ export const txForErc20 = (tx, token) => {
  * passed to post$(tx).
  */
 export const txForEth = tx => {
-  return {
+  let output = {
     from: tx.from,
     gasPrice: toWei(tx.gasPrice, 'shannon'), // shannon == gwei
     to: tx.to,
     value: toWei(tx.amount.toString())
   };
+  // gas field should not be present when the function is called for gas estimation.
+  if (tx.gas) {
+    output.gas = tx.gas;
+  }
+  return output;
 };

--- a/packages/fether-react/src/utils/estimateGas.js
+++ b/packages/fether-react/src/utils/estimateGas.js
@@ -95,7 +95,7 @@ export const txForErc20 = (tx, token) => {
  * passed to post$(tx).
  */
 export const txForEth = tx => {
-  let output = {
+  const output = {
     from: tx.from,
     gasPrice: toWei(tx.gasPrice, 'shannon'), // shannon == gwei
     to: tx.to,

--- a/packages/fether-react/src/utils/estimateGas.js
+++ b/packages/fether-react/src/utils/estimateGas.js
@@ -78,7 +78,7 @@ const addBuffer = estimated => {
  * passed to makeContract.transfer(...).
  */
 export const txForErc20 = (tx, token) => {
-  return {
+  const output = {
     args: [
       tx.to,
       new BigNumber(tx.amount).mul(new BigNumber(10).pow(token.decimals))
@@ -88,6 +88,12 @@ export const txForErc20 = (tx, token) => {
       gasPrice: toWei(tx.gasPrice, 'shannon') // shannon == gwei
     }
   };
+
+  if (tx.gas) {
+    output.options.gas = tx.gas;
+  }
+
+  return output;
 };
 
 /**

--- a/packages/fether-react/src/utils/withHealth.js
+++ b/packages/fether-react/src/utils/withHealth.js
@@ -113,7 +113,7 @@ const rpcs$ = isApiConnected$.pipe(
         // as syncing to new blocks from the top of the chain usually takes ~1s.
         // syncStatus$() is distinctUntilChanged, so {isSync: false} will never
         // be fired twice in a row.
-        switchMap(sync => sync.isSync ? of(sync) : of(sync).pipe(delay(2000)))
+        switchMap(sync => (sync.isSync ? of(sync) : of(sync).pipe(delay(2000))))
       ),
       peerCount$().pipe(withoutLoading())
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6127,6 +6127,11 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+final-form-calculate@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/final-form-calculate/-/final-form-calculate-1.2.1.tgz#906f09e2d3410b3338a94b596062848d9b7c7d03"
+  integrity sha512-uAmVfJ68Qe8HEs7fzbe+u2UJ89ZFAEa9LIfDKVNm4KDeSXGvSe/e2XODRjayvm34X36SmkP8TJMmsRd6OW8oRw==
+
 final-form@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.8.3.tgz#86a03da6cd6459ed8fe3737dbd9dc87ed40c11d7"


### PR DESCRIPTION
- Do not add any "gas buffer" (currently 25% for any transaction) when we realize that the transaction is between 2 accounts, and therefore costs invariably 21'000 Wei
- Pass the gas information to the `parity_postTransaction` RPC to prevent any error from the node. The node knows nothing about the transaction and does not estimate gas (too costly) so it defaults to an amount of gas that is much greater than 21000.
- Should fix https://github.com/paritytech/fether/issues/265 and #250 