### PR TITLE
fix: Fixes #251. Show tooltip warning when user enters amount of less than 1 Wei

### DIFF
--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -164,7 +164,9 @@ class Send extends Component {
     if (!amount || isNaN(amount)) {
       return { amount: 'Please enter a valid amount' };
     } else if (amount < 0) {
-      return { amount: 'Please enter a positive amount ' };
+      return { amount: 'Please enter a positive amount' };
+    } else if (toWei(values.amount).lt(1)) {
+      return { amount: 'Please enter at least 1 Wei' };
     } else if (balance && balance.lt(amount)) {
       return { amount: `You don't have enough ${token.symbol} balance` };
     } else if (!values.to || !isAddress(values.to)) {


### PR DESCRIPTION
Screenshot:

<img width="355" alt="screenshot 2018-12-13 at 19 53 22" src="https://user-images.githubusercontent.com/6226175/49961517-21b87b80-ff13-11e8-853d-6959bcff9de6.png">
