### PR TITLE
feat: Relates to #98. Add Etherscan account or token link to send page TokenBalance component

### DIFF
--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -5,6 +5,8 @@
 
 import React, { Component } from 'react';
 import BigNumber from 'bignumber.js';
+import { chainName$, isLoading } from '@parity/light.js';
+import light from '@parity/light.js-react';
 import createDecorator from 'final-form-calculate';
 import debounce from 'debounce-promise';
 import { Field, Form } from 'react-final-form';
@@ -26,6 +28,9 @@ const MAX_GAS_PRICE = 40; // In Gwei
 const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 
 @inject('parityStore', 'sendStore')
+@light({
+  chainName: chainName$
+})
 @withTokens
 @withProps(({ match: { params: { tokenAddress } }, tokens }) => ({
   token: tokens[tokenAddress]
@@ -57,6 +62,27 @@ class Send extends Component {
       }
     }
   });
+
+  openEtherscanLink () {
+    const { accountAddress, chainName, token } = this.props;
+    const chainNamePrefix = isLoading(chainName) ? '' : `${chainName}`;
+
+    if (!accountAddress || !chainNamePrefix || !token.address) {
+      return;
+    }
+
+    const getEthereumAddress = () =>
+      `https://${chainNamePrefix}.etherscan.io/address/${accountAddress}`;
+    const getTokenAddress = () =>
+      `https://${chainNamePrefix}.etherscan.io/token/${
+        token.address
+      }?a=${accountAddress}`;
+
+    const href =
+      token.address === 'ETH' ? getEthereumAddress() : getTokenAddress();
+
+    window.open(href, '_blank');
+  }
 
   render () {
     const {
@@ -148,7 +174,7 @@ class Send extends Component {
                     )}
                   />
                 ]}
-                onClick={null} // To disable cursor:pointer on card // TODO Can this be done better?
+                onClick={() => this.openEtherscanLink()} // To disable cursor:pointer on card // TODO Can this be done better?
                 token={token}
               />
             </div>

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -71,15 +71,11 @@ class Send extends Component {
       return;
     }
 
-    const getEthereumAddress = () =>
-      `https://${chainNamePrefix}.etherscan.io/address/${accountAddress}`;
-    const getTokenAddress = () =>
-      `https://${chainNamePrefix}.etherscan.io/token/${
-        token.address
-      }?a=${accountAddress}`;
-
-    const href =
-      token.address === 'ETH' ? getEthereumAddress() : getTokenAddress();
+    const baseUrl = `https://${chainNamePrefix}.etherscan.io`;
+    const getEthAddr = () => `${baseUrl}/address/${accountAddress}`;
+    const getTokenAddr = () =>
+      `${baseUrl}/token/${token.address}?a=${accountAddress}`;
+    const href = token.address === 'ETH' ? getEthAddr() : getTokenAddr();
 
     window.open(href, '_blank');
   }

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -72,10 +72,10 @@ class Send extends Component {
     }
 
     const baseUrl = `https://${chainNamePrefix}.etherscan.io`;
-    const getEthAddr = () => `${baseUrl}/address/${accountAddress}`;
-    const getTokenAddr = () =>
+    const ethUrl = () => `${baseUrl}/address/${accountAddress}`;
+    const tokenUrl = () =>
       `${baseUrl}/token/${token.address}?a=${accountAddress}`;
-    const href = token.address === 'ETH' ? getEthAddr() : getTokenAddr();
+    const href = token.address === 'ETH' ? ethUrl() : tokenUrl();
 
     window.open(href, '_blank');
   }


### PR DESCRIPTION
* Opens link to the Etherscan account page when the user clicks the TokenBalance component (the area shown in 'purple' colour below) on the "Send Ether" page

<img width="358" alt="screen shot 2018-12-19 at 8 07 37 pm" src="https://user-images.githubusercontent.com/6226175/50235860-f4177a80-03c9-11e9-8c74-e51b03706904.png">

* Opens link to directly to the specific token page of the Etherscan account when the user clicks the TokenBalance component on the "Send THIBCoin" (or other non-Ether token) page

<img width="353" alt="screen shot 2018-12-19 at 8 07 46 pm" src="https://user-images.githubusercontent.com/6226175/50235865-f8439800-03c9-11e9-8d96-1f0295dc396d.png">