### PR TITLE
docs: Add troubleshooting tip suggesting to reload when stuck on white screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ yarn package
 yarn start
 ```
 
+> Troubleshooting: If it hangs on a white screen in Electron even though it has compiled and has been syncing for a long time, then simply choose 'View > Reload' (CMD + R on macOS) from the Electron menu
+
 ## Join the chat!
 
 Get in touch with us on Gitter:


### PR DESCRIPTION
When running `yarn start` the Electron screen may just remain white indefinitely even though it said it compiled and has been syncing blocks for a while. Instead of having to resort to using `yarn electron` (which doesn't have this issue, but doesn't provide benefits such as live reload and more detailed debugging), the solution appears to be as simple as going to 'View > Reload' in the Electron menu (or entering shortcut CMD + R on macOS)