### PR TITLE
feat: Fixes #308. Change amount font size on Send page to fit in input field

### DIFF
--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -63,15 +63,10 @@ class Send extends Component {
     }
   });
 
-  changeAmountFontSize = values => {
-    if (!values.amount) {
-      return '-resize-font-default';
-    }
-
-    return values.amount.toString().length > DEFAULT_AMOUNT_MAX_CHARS
+  changeAmountFontSize = amount =>
+    amount.toString().length > DEFAULT_AMOUNT_MAX_CHARS
       ? '-resize-font-small' // Resize to fit an amount as small as one Wei
       : '-resize-font-default';
-  };
 
   calculateMax = (gas, gasPrice) => {
     const { token, balance } = this.props;
@@ -145,9 +140,11 @@ class Send extends Component {
                         <fieldset className='form_fields'>
                           <Field
                             autoFocus
-                            className={`form_field_amount ${this.changeAmountFontSize(
-                              values
-                            )}`}
+                            className={`form_field_amount ${
+                              !values.amount
+                                ? '-resize-font-default'
+                                : this.changeAmountFontSize(values.amount)
+                            }`}
                             formNoValidate
                             label='Amount'
                             name='amount'

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -24,6 +24,7 @@ import withBalance, { withEthBalance } from '../../utils/withBalance';
 import withTokens from '../../utils/withTokens';
 
 const DEFAULT_AMOUNT_MAX_CHARS = 9;
+const MEDIUM_AMOUNT_MAX_CHARS = 14;
 const MAX_GAS_PRICE = 40; // In Gwei
 const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 
@@ -63,10 +64,18 @@ class Send extends Component {
     }
   });
 
-  changeAmountFontSize = amount =>
-    amount.toString().length > DEFAULT_AMOUNT_MAX_CHARS
-      ? '-resize-font-small' // Resize to fit an amount as small as one Wei
-      : '-resize-font-default';
+  changeAmountFontSize = amount => {
+    const amountLen = amount.toString().length;
+    if (amountLen > MEDIUM_AMOUNT_MAX_CHARS) {
+      return '-resize-font-small'; // Resize to fit an amount as small as one Wei
+    } else if (
+      MEDIUM_AMOUNT_MAX_CHARS >= amountLen &&
+      amountLen > DEFAULT_AMOUNT_MAX_CHARS
+    ) {
+      return '-resize-font-medium';
+    }
+    return '-resize-font-default';
+  };
 
   calculateMax = (gas, gasPrice) => {
     const { token, balance } = this.props;

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -44,13 +44,6 @@ class Send extends Component {
     showDetails: false
   };
 
-  handleSubmit = values => {
-    const { accountAddress, history, sendStore, token } = this.props;
-
-    sendStore.setTx(values);
-    history.push(`/send/${token.address}/from/${accountAddress}/signer`);
-  };
-
   decorator = createDecorator({
     field: /to|amount/, // when the value of these fields change...
     updates: {

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -23,9 +23,7 @@ import withAccount from '../../utils/withAccount.js';
 import withBalance, { withEthBalance } from '../../utils/withBalance';
 import withTokens from '../../utils/withTokens';
 
-const DEFAULT_AMOUNT_FONT_SIZE = 3;
 const DEFAULT_AMOUNT_MAX_CHARS = 9;
-const AMOUNT_RESIZE_FONT_SIZE = 0.47 * DEFAULT_AMOUNT_FONT_SIZE; // Fits 1 Wei
 const MAX_GAS_PRICE = 40; // In Gwei
 const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 
@@ -65,21 +63,14 @@ class Send extends Component {
     }
   });
 
-  changeAmountFontSize = () => {
-    const amountElement = document.getElementById('amount');
-
-    if (!amountElement) {
-      return;
+  changeAmountFontSize = values => {
+    if (!values.amount) {
+      return '-resize-font-default';
     }
 
-    if (
-      amountElement.scrollWidth > amountElement.offsetWidth ||
-      amountElement.value.length > DEFAULT_AMOUNT_MAX_CHARS
-    ) {
-      amountElement.style.fontSize = `${AMOUNT_RESIZE_FONT_SIZE}rem`;
-    } else {
-      amountElement.style.fontSize = `${DEFAULT_AMOUNT_FONT_SIZE}rem`;
-    }
+    return values.amount.toString().length > DEFAULT_AMOUNT_MAX_CHARS
+      ? '-resize-font-small' // Resize to fit an amount as small as one Wei
+      : '-resize-font-default';
   };
 
   calculateMax = (gas, gasPrice) => {
@@ -154,7 +145,9 @@ class Send extends Component {
                         <fieldset className='form_fields'>
                           <Field
                             autoFocus
-                            className='form_field_amount'
+                            className={`form_field_amount ${this.changeAmountFontSize(
+                              values
+                            )}`}
                             formNoValidate
                             label='Amount'
                             name='amount'
@@ -179,12 +172,6 @@ class Send extends Component {
                               Max
                             </button>
                           </Field>
-
-                          <OnChange name='amount'>
-                            {(value, previous) => {
-                              this.changeAmountFontSize();
-                            }}
-                          </OnChange>
 
                           <Field
                             as='textarea'
@@ -215,8 +202,6 @@ class Send extends Component {
                             {(value, previous) => {
                               if (this.state.maxSelected) {
                                 mutators.recalculateMax();
-                              } else {
-                                this.changeAmountFontSize();
                               }
                             }}
                           </OnChange>

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -23,6 +23,9 @@ import withAccount from '../../utils/withAccount.js';
 import withBalance, { withEthBalance } from '../../utils/withBalance';
 import withTokens from '../../utils/withTokens';
 
+const DEFAULT_AMOUNT_FONT_SIZE = 3;
+const DEFAULT_AMOUNT_MAX_CHARS = 9;
+const AMOUNT_RESIZE_FONT_SIZE = 0.47 * DEFAULT_AMOUNT_FONT_SIZE; // Fits 1 Wei
 const MAX_GAS_PRICE = 40; // In Gwei
 const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 
@@ -39,6 +42,7 @@ class Send extends Component {
   state = {
     maxSelected: false
   };
+
   handleSubmit = values => {
     const { accountAddress, history, sendStore, token } = this.props;
 
@@ -60,6 +64,23 @@ class Send extends Component {
       }
     }
   });
+
+  changeAmountFontSize = () => {
+    const amountElement = document.getElementById('amount');
+
+    if (!amountElement) {
+      return;
+    }
+
+    if (
+      amountElement.scrollWidth > amountElement.offsetWidth ||
+      amountElement.value.length > DEFAULT_AMOUNT_MAX_CHARS
+    ) {
+      amountElement.style.fontSize = `${AMOUNT_RESIZE_FONT_SIZE}rem`;
+    } else {
+      amountElement.style.fontSize = `${DEFAULT_AMOUNT_FONT_SIZE}rem`;
+    }
+  };
 
   calculateMax = (gas, gasPrice) => {
     const { token, balance } = this.props;
@@ -158,6 +179,12 @@ class Send extends Component {
                             </button>
                           </Field>
 
+                          <OnChange name='amount'>
+                            {(value, previous) => {
+                              this.changeAmountFontSize();
+                            }}
+                          </OnChange>
+
                           <Field
                             as='textarea'
                             className='-sm'
@@ -187,6 +214,8 @@ class Send extends Component {
                             {(value, previous) => {
                               if (this.state.maxSelected) {
                                 mutators.recalculateMax();
+                              } else {
+                                this.changeAmountFontSize();
                               }
                             }}
                           </OnChange>

--- a/packages/fether-react/src/assets/sass/shared/_form.scss
+++ b/packages/fether-react/src/assets/sass/shared/_form.scss
@@ -130,6 +130,8 @@ input.form_field_amount[type='number'] {
   width: 100%;
   text-align: center;
   -webkit-appearance: none;
+  -webkit-transition: font-size 0.5s;
+  transition: font-size 0.5s;
 
   &.-resize-font-default {
     font-size: ms(6);

--- a/packages/fether-react/src/assets/sass/shared/_form.scss
+++ b/packages/fether-react/src/assets/sass/shared/_form.scss
@@ -137,6 +137,10 @@ input.form_field_amount[type='number'] {
     font-size: ms(6);
   }
 
+  &.-resize-font-medium {
+    font-size: ms(4);
+  }
+
   &.-resize-font-small {
     font-size: ms(2);
   }

--- a/packages/fether-react/src/assets/sass/shared/_form.scss
+++ b/packages/fether-react/src/assets/sass/shared/_form.scss
@@ -132,11 +132,11 @@ input.form_field_amount[type='number'] {
   -webkit-appearance: none;
 
   &.-resize-font-default {
-    font-size: ms(6); /* 3rem */
+    font-size: ms(6);
   }
 
   &.-resize-font-small {
-    font-size: 1.41rem; /* 0.47 * default */
+    font-size: ms(2);
   }
 
   &::-webkit-inner-spin-button,

--- a/packages/fether-react/src/assets/sass/shared/_form.scss
+++ b/packages/fether-react/src/assets/sass/shared/_form.scss
@@ -125,12 +125,19 @@
 }
 
 input.form_field_amount[type='number'] {
-  font-size: ms(6);
   line-height: ms(6) * 1.1;
   font-weight: 200;
   width: 100%;
   text-align: center;
   -webkit-appearance: none;
+
+  &.-resize-font-default {
+    font-size: ms(6); /* 3rem */
+  }
+
+  &.-resize-font-small {
+    font-size: 1.41rem; /* 0.47 * default */
+  }
 
   &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button {


### PR DESCRIPTION
* Switches to font size that fits a value as small as 1 Wei on the screen when more than 9 digits entered

* Switches back to default font size when amount of digits entered is 9 or less again

* Caters for when user unchecks the Max Value button