### PR TITLE
fix: Fixes #320. Memoize form field values in state to prevent reseting on sync

### DIFF
--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -89,9 +89,11 @@ class Send extends Component {
       form: { amount, gasPrice, to }
     } = this.state;
 
-    this.setState({ form: { amount: fieldValue, gasPrice, to } });
+    const newValue = fieldValue || amount;
 
-    return fieldValue || amount;
+    this.setState({ form: { amount: newValue, gasPrice, to } });
+
+    return newValue;
   };
 
   onChangeGasPrice = fieldValue => {
@@ -99,7 +101,9 @@ class Send extends Component {
       form: { amount, gasPrice, to }
     } = this.state;
 
-    this.setState({ form: { amount, gasPrice: fieldValue, to } });
+    const newValue = fieldValue || gasPrice;
+
+    this.setState({ form: { amount, gasPrice: newValue, to } });
 
     return fieldValue || gasPrice;
   };
@@ -109,9 +113,11 @@ class Send extends Component {
       form: { amount, gasPrice, to }
     } = this.state;
 
-    this.setState({ form: { amount, gasPrice, to: fieldValue } });
+    const newValue = fieldValue || to;
 
-    return fieldValue || to;
+    this.setState({ form: { amount, gasPrice, to: newValue } });
+
+    return newValue;
   };
 
   recalculateMax = (args, state, { changeValue }) => {

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -39,9 +39,9 @@ class Send extends Component {
   state = {
     maxSelected: false,
     form: {
-      amount: null,
+      amount: '',
       gasPrice: '4',
-      to: null
+      to: ''
     }
   };
 
@@ -89,11 +89,9 @@ class Send extends Component {
       form: { amount, gasPrice, to }
     } = this.state;
 
-    const newValue = fieldValue || amount;
+    this.setState({ form: { amount: fieldValue, gasPrice, to } });
 
-    this.setState({ form: { amount: newValue, gasPrice, to } });
-
-    return newValue;
+    return fieldValue;
   };
 
   onChangeGasPrice = fieldValue => {
@@ -101,11 +99,9 @@ class Send extends Component {
       form: { amount, gasPrice, to }
     } = this.state;
 
-    const newValue = fieldValue || gasPrice;
+    this.setState({ form: { amount, gasPrice: fieldValue, to } });
 
-    this.setState({ form: { amount, gasPrice: newValue, to } });
-
-    return fieldValue || gasPrice;
+    return fieldValue;
   };
 
   onChangeTo = fieldValue => {
@@ -113,11 +109,9 @@ class Send extends Component {
       form: { amount, gasPrice, to }
     } = this.state;
 
-    const newValue = fieldValue || to;
+    this.setState({ form: { amount, gasPrice, to: fieldValue } });
 
-    this.setState({ form: { amount, gasPrice, to: newValue } });
-
-    return newValue;
+    return fieldValue;
   };
 
   recalculateMax = (args, state, { changeValue }) => {

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -37,8 +37,14 @@ const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
 @observer
 class Send extends Component {
   state = {
-    maxSelected: false
+    maxSelected: false,
+    form: {
+      amount: null,
+      gasPrice: '4',
+      to: null
+    }
   };
+
   handleSubmit = values => {
     const { accountAddress, history, sendStore, token } = this.props;
 
@@ -78,12 +84,46 @@ class Send extends Component {
     return output;
   };
 
+  onChangeAmount = fieldValue => {
+    const {
+      form: { amount, gasPrice, to }
+    } = this.state;
+
+    this.setState({ form: { amount: fieldValue, gasPrice, to } });
+
+    return fieldValue || amount;
+  };
+
+  onChangeGasPrice = fieldValue => {
+    const {
+      form: { amount, gasPrice, to }
+    } = this.state;
+
+    this.setState({ form: { amount, gasPrice: fieldValue, to } });
+
+    return fieldValue || gasPrice;
+  };
+
+  onChangeTo = fieldValue => {
+    const {
+      form: { amount, gasPrice, to }
+    } = this.state;
+
+    this.setState({ form: { amount, gasPrice, to: fieldValue } });
+
+    return fieldValue || to;
+  };
+
   recalculateMax = (args, state, { changeValue }) => {
     changeValue(state, 'amount', value => {
-      return this.calculateMax(
+      const max = this.calculateMax(
         state.formState.values.gas,
         state.formState.values.gasPrice
       );
+
+      this.onChangeAmount(max);
+
+      return max;
     });
   };
 
@@ -97,6 +137,10 @@ class Send extends Component {
       sendStore: { tx },
       token
     } = this.props;
+
+    const {
+      form: { amount, gasPrice, to }
+    } = this.state;
 
     return (
       <div>
@@ -117,7 +161,13 @@ class Send extends Component {
                 drawers={[
                   <Form
                     key='txForm'
-                    initialValues={{ from: accountAddress, gasPrice: 4, ...tx }}
+                    initialValues={{
+                      amount,
+                      from: accountAddress,
+                      gasPrice,
+                      to,
+                      ...tx
+                    }}
                     onSubmit={this.handleSubmit}
                     validate={this.validateForm}
                     decorators={[this.decorator]}
@@ -137,6 +187,7 @@ class Send extends Component {
                             label='Amount'
                             name='amount'
                             disabled={this.state.maxSelected}
+                            parse={this.onChangeAmount}
                             placeholder='0.00'
                             render={FetherForm.Field}
                             required
@@ -163,6 +214,7 @@ class Send extends Component {
                             className='-sm'
                             label='To'
                             name='to'
+                            parse={this.onChangeTo}
                             placeholder='0x...'
                             required
                             render={FetherForm.Field}
@@ -176,6 +228,7 @@ class Send extends Component {
                             max={MAX_GAS_PRICE}
                             min={MIN_GAS_PRICE}
                             name='gasPrice'
+                            parse={this.onChangeGasPrice}
                             render={FetherForm.Slider}
                             required
                             rightText='High'

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -86,7 +86,7 @@ class Send extends Component {
 
   onChangeAmount = fieldValue => {
     const {
-      form: { amount, gasPrice, to }
+      form: { gasPrice, to }
     } = this.state;
 
     this.setState({ form: { amount: fieldValue, gasPrice, to } });
@@ -96,7 +96,7 @@ class Send extends Component {
 
   onChangeGasPrice = fieldValue => {
     const {
-      form: { amount, gasPrice, to }
+      form: { amount, to }
     } = this.state;
 
     this.setState({ form: { amount, gasPrice: fieldValue, to } });
@@ -106,7 +106,7 @@ class Send extends Component {
 
   onChangeTo = fieldValue => {
     const {
-      form: { amount, gasPrice, to }
+      form: { amount, gasPrice }
     } = this.state;
 
     this.setState({ form: { amount, gasPrice, to: fieldValue } });


### PR DESCRIPTION
* Uses `parse` property of the react-final-form Field for the `amount`, `gasPrice`, and `to` input fields, which is passed the current input field value and returns the value to be shown on the form, but we use it to backup/store the current value of the form in the component's state, and just return the current input value back again. We use these stored values when form initialises so `initialValues` correspond to the values stored in the state, which prevents all the form input field values disappearing and causing the user to have to re-enter them all again if syncing or bad connectivity occurs after they have entered values but not yet finished sending the transaction.

Refer to below video showing how the form field values aren't reset when a sync occurs
https://drive.google.com/open?id=14APiLMK6zDoUjCS2DST6VkHtOAmbTrw8

Relates to #218 