### PR TITLE
fix: Relates to #138. Prevents user from importing account that is already in account list

### DIFF
--- a/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
@@ -46,9 +46,7 @@ class AccountImportOptions extends Component {
     try {
       await setPhrase(phrase);
 
-      const addressForPhrase = createAccountStore.address.toLowerCase();
-
-      if (this.hasExistingAddressForImport(addressForPhrase)) {
+      if (this.hasExistingAddressForImport(createAccountStore.address)) {
         return;
       }
 
@@ -72,9 +70,8 @@ class AccountImportOptions extends Component {
 
     try {
       const json = JSON.parse(jsonString);
-      const jsonAddress = `0x${json['address'].toLowerCase()}`;
 
-      if (this.hasExistingAddressForImport(jsonAddress)) {
+      if (this.hasExistingAddressForImport(`0x${json['address']}`)) {
         return;
       }
 
@@ -94,7 +91,7 @@ class AccountImportOptions extends Component {
     const { accounts } = this.props;
     const isExistingAddress = accounts
       .map(address => address && address.toLowerCase())
-      .includes(addressForImport);
+      .includes(addressForImport.toLowerCase());
 
     if (isExistingAddress) {
       this.setState({

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import React, { Component } from 'react';
-import { Card, Form as FetherForm } from 'fether-ui';
+import { addressShort, Card, Form as FetherForm } from 'fether-ui';
 import { accounts$, withoutLoading } from '@parity/light.js';
 import light from '@parity/light.js-react';
 import { inject, observer } from 'mobx-react';
@@ -99,7 +99,7 @@ class AccountImportOptions extends Component {
     if (isExistingAddress) {
       this.setState({
         isLoading: false,
-        error: `Account already loaded. Address ${addressForImport} is already in the account list`
+        error: `Account ${addressShort(addressForImport)} already listed`
       });
     }
 

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
@@ -5,12 +5,12 @@
 
 import React, { Component } from 'react';
 import { Card, Form as FetherForm } from 'fether-ui';
-import { accountsInfo$, withoutLoading } from '@parity/light.js';
+import { accounts$, withoutLoading } from '@parity/light.js';
 import light from '@parity/light.js-react';
 import { inject, observer } from 'mobx-react';
 
 @light({
-  accountsInfo: () => accountsInfo$().pipe(withoutLoading())
+  accounts: () => accounts$().pipe(withoutLoading())
 })
 @inject('createAccountStore')
 @observer
@@ -91,8 +91,8 @@ class AccountImportOptions extends Component {
   };
 
   hasExistingAddressForImport = addressForImport => {
-    const { accountsInfo } = this.props;
-    const isExistingAddress = Object.keys(accountsInfo)
+    const { accounts } = this.props;
+    const isExistingAddress = accounts
       .map(address => address && address.toLowerCase())
       .includes(addressForImport);
 

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
@@ -71,9 +71,8 @@ class AccountImportOptions extends Component {
     this.setState({ isLoading: true });
 
     try {
-      const jsonAddress = `0x${JSON.parse(jsonString)[
-        'address'
-      ].toLowerCase()}`;
+      const json = JSON.parse(jsonString);
+      const jsonAddress = `0x${json['address'].toLowerCase()}`;
 
       if (this.hasExistingAddressForImport(jsonAddress)) {
         return;

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountImportOptions/AccountImportOptions.js
@@ -63,19 +63,19 @@ class AccountImportOptions extends Component {
 
   handleChangeFile = async jsonString => {
     const {
+      createAccountStore,
       createAccountStore: { setJsonString }
     } = this.props;
 
     this.setState({ isLoading: true });
 
     try {
-      const json = JSON.parse(jsonString);
+      await setJsonString(jsonString);
 
-      if (this.hasExistingAddressForImport(`0x${json['address']}`)) {
+      if (this.hasExistingAddressForImport(createAccountStore.address)) {
         return;
       }
 
-      await setJsonString(jsonString);
       this.handleNextStep();
     } catch (error) {
       this.setState({

--- a/packages/fether-ui/src/AddressShort/AddressShort.js
+++ b/packages/fether-ui/src/AddressShort/AddressShort.js
@@ -6,12 +6,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { addressShort } from '../utils/addressShort';
+
 export const AddressShort = ({ address, as: T = 'span', ...otherProps }) => (
-  <T {...otherProps}>
-    {address.slice(0, 6)}
-    ..
-    {address.slice(-4)}
-  </T>
+  <T {...otherProps}>{addressShort(address)}</T>
 );
 
 AddressShort.propTypes = {

--- a/packages/fether-ui/src/index.js
+++ b/packages/fether-ui/src/index.js
@@ -11,3 +11,4 @@ export * from './Form';
 export * from './Header';
 export * from './Placeholder';
 export * from './TokenCard';
+export * from './utils';

--- a/packages/fether-ui/src/utils/addressShort.js
+++ b/packages/fether-ui/src/utils/addressShort.js
@@ -1,0 +1,7 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+export const addressShort = address =>
+  address ? `${address.slice(0, 6)}..${address.slice(-4)}` : '';

--- a/packages/fether-ui/src/utils/index.js
+++ b/packages/fether-ui/src/utils/index.js
@@ -1,0 +1,6 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+export * from './addressShort';


### PR DESCRIPTION
* Prevents user from importing account and show the message in the screenshot below when they go to "Import account" and select a JSON Backup Keyfile whose address is already associated with an account that is already in the account list

* Prevents user from importing account and show the message in the screenshot below when they go to "Import account" and enter a Seed Phrase that corresponds to an address that is associated with an account that is already in the account list

<img width="358" alt="screen shot 2018-12-28 at 2 03 42 pm" src="https://user-images.githubusercontent.com/6226175/50501391-ee95f080-0aab-11e9-9683-0779f4969ae8.png">
