### PR TITLE
Merge into yj-focus-formfield - Don't use keycodes

### DIFF
--- a/packages/fether-react/src/Accounts/CreateAccount/AccountCopyPhrase/AccountCopyPhrase.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountCopyPhrase/AccountCopyPhrase.js
@@ -6,7 +6,6 @@
 import React, { Component } from 'react';
 import { AccountCard } from 'fether-ui';
 import { inject, observer } from 'mobx-react';
-import { Link } from 'react-router-dom';
 
 @inject('createAccountStore')
 @observer

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountCopyPhrase/AccountCopyPhrase.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountCopyPhrase/AccountCopyPhrase.js
@@ -11,6 +11,17 @@ import { Link } from 'react-router-dom';
 @inject('createAccountStore')
 @observer
 class AccountCopyPhrase extends Component {
+  handleSubmit = () => {
+    const {
+      history,
+      location: { pathname }
+    } = this.props;
+
+    const currentStep = pathname.slice(-1);
+
+    history.push(`/accounts/new/${+currentStep + 1}`);
+  };
+
   render () {
     const {
       createAccountStore: { address, name, bip39Phrase },
@@ -24,7 +35,7 @@ class AccountCopyPhrase extends Component {
         address={address}
         name={name}
         drawers={[
-          <div key='createAccount'>
+          <form key='createAccount' onSubmit={this.handleSubmit}>
             <div className='text'>
               <p>Please write your secret phrase on a piece of paper:</p>
             </div>
@@ -46,15 +57,19 @@ class AccountCopyPhrase extends Component {
             </div>
             <nav className='form-nav -space-around'>
               {currentStep > 1 && (
-                <button className='button -cancel' onClick={history.goBack}>
+                <button
+                  className='button -cancel'
+                  onClick={history.goBack}
+                  type='button'
+                >
                   Back
                 </button>
               )}
-              <Link to={`/accounts/new/${+currentStep + 1}`}>
-                <button className='button'>Next</button>
-              </Link>
+              <button autoFocus className='button'>
+                Next
+              </button>
             </nav>
-          </div>
+          </form>
         ]}
       />
     );

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
@@ -25,15 +25,7 @@ class AccountName extends Component {
   handleChangeName = ({ target: { value } }) =>
     this.props.createAccountStore.setName(value);
 
-  render () {
-    const {
-      createAccountStore: { isImport }
-    } = this.props;
-
-    return isImport ? this.renderCardWhenImported() : this.renderCardWhenNew();
-  }
-
-  handleKeyPress = e => {
+  handleSubmit = () => {
     const {
       history,
       location: { pathname }
@@ -41,10 +33,16 @@ class AccountName extends Component {
 
     const currentStep = pathname.slice(-1);
 
-    if (e.key === 'Enter') {
-      history.push(`/accounts/new/${+currentStep + 1}`);
-    }
+    history.push(`/accounts/new/${+currentStep + 1}`);
   };
+
+  render () {
+    const {
+      createAccountStore: { isImport }
+    } = this.props;
+
+    return isImport ? this.renderCardWhenImported() : this.renderCardWhenNew();
+  }
 
   renderCardWhenImported = () => {
     const {
@@ -98,15 +96,13 @@ class AccountName extends Component {
     const currentStep = pathname.slice(-1);
 
     return (
-      <div key='createAccount'>
+      <form key='createAccount' onSubmit={this.handleSubmit}>
         <div className='text'>
           <p>Please give this account a name:</p>
         </div>
         <FetherForm.Field
           label='Name'
           onChange={this.handleChangeName}
-          onKeyPress={this.handleKeyPress}
-          onSubmit={() => history.push(`/accounts/new/${+currentStep + 1}`)}
           autoFocus
           required
           type='text'
@@ -119,16 +115,14 @@ class AccountName extends Component {
             </button>
           )}
           {name && address ? (
-            <Link to={`/accounts/new/${+currentStep + 1}`}>
-              <button className='button'>Next</button>
-            </Link>
+            <button className='button'>Next</button>
           ) : (
             <button className='button' disabled>
               Next
             </button>
           )}
         </nav>
-      </div>
+      </form>
     );
   };
 }

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import { AccountCard, Card, Form as FetherForm } from 'fether-ui';
 import Blockies from 'react-blockies';
 import { inject, observer } from 'mobx-react';
-import { Link } from 'react-router-dom';
 
 import loading from '../../../assets/img/icons/loading.svg';
 
@@ -110,7 +109,11 @@ class AccountName extends Component {
         />
         <nav className='form-nav -space-around'>
           {currentStep > 1 && (
-            <button className='button -cancel' onClick={history.goBack}>
+            <button
+              className='button -cancel'
+              onClick={history.goBack}
+              type='button'
+            >
               Back
             </button>
           )}

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountPassword/AccountPassword.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountPassword/AccountPassword.js
@@ -85,7 +85,6 @@ class AccountPassword extends Component {
               label='Password'
               autoFocus
               onChange={this.handlePasswordChange}
-              onSubmit={jsonString && this.handleSubmit}
               required
               type='password'
               value={password}
@@ -95,7 +94,6 @@ class AccountPassword extends Component {
               <FetherForm.Field
                 label='Confirm'
                 onChange={this.handleConfirmChange}
-                onSubmit={this.handleSubmit}
                 autoFocus={false}
                 required
                 type='password'
@@ -119,6 +117,7 @@ class AccountPassword extends Component {
               )}
               <button
                 className='button'
+                autoFocus
                 disabled={
                   !password ||
                   (!jsonString && confirm !== password) ||

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountPassword/AccountPassword.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountPassword/AccountPassword.js
@@ -94,7 +94,6 @@ class AccountPassword extends Component {
               <FetherForm.Field
                 label='Confirm'
                 onChange={this.handleConfirmChange}
-                autoFocus={false}
                 required
                 type='password'
                 value={confirm}

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountPassword/AccountPassword.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountPassword/AccountPassword.js
@@ -109,7 +109,11 @@ class AccountPassword extends Component {
 
             <nav className='form-nav -space-around'>
               {currentStep > 1 && (
-                <button className='button -cancel' onClick={history.goBack}>
+                <button
+                  className='button -cancel'
+                  onClick={history.goBack}
+                  type='button'
+                >
                   Back
                 </button>
               )}

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountRewritePhrase/AccountRewritePhrase.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountRewritePhrase/AccountRewritePhrase.js
@@ -21,7 +21,7 @@ class AccountRewritePhrase extends Component {
     this.setState({ value });
   };
 
-  handleNextStep = async () => {
+  handleSubmit = async () => {
     const {
       history,
       location: { pathname },
@@ -48,7 +48,7 @@ class AccountRewritePhrase extends Component {
     const { value } = this.state;
     const currentStep = pathname.slice(-1);
     const body = [
-      <div key='createAccount'>
+      <form key='createAccount' onSubmit={this.handleSubmit}>
         <div className='text -centered'>
           {isImport ? (
             <AccountImportOptions />
@@ -64,7 +64,6 @@ class AccountRewritePhrase extends Component {
           as='textarea'
           label='Recovery phrase'
           autoFocus
-          onSubmit={this.handleNextStep}
           onChange={this.handleChange}
           required
           value={value}
@@ -72,13 +71,17 @@ class AccountRewritePhrase extends Component {
 
         <nav className='form-nav -space-around'>
           {currentStep > 1 && (
-            <button className='button -cancel' onClick={history.goBack}>
+            <button
+              className='button -cancel'
+              onClick={history.goBack}
+              type='button'
+            >
               Back
             </button>
           )}
           {this.renderButton()}
         </nav>
-      </div>
+      </form>
     ];
 
     return isImport ? (
@@ -102,11 +105,7 @@ class AccountRewritePhrase extends Component {
     // been correctly written by the user.
     if (!isImport) {
       return (
-        <button
-          className='button'
-          disabled={value !== bip39Phrase}
-          onClick={this.handleNextStep}
-        >
+        <button className='button' disabled={value !== bip39Phrase}>
           Next
         </button>
       );
@@ -114,11 +113,7 @@ class AccountRewritePhrase extends Component {
 
     // If we are importing an existing account, the button goes to the next step
     return (
-      <button
-        className='button'
-        disabled={!value.length || isLoading}
-        onClick={this.handleNextStep}
-      >
+      <button className='button' disabled={!value.length || isLoading}>
         Next
       </button>
     );

--- a/packages/fether-react/src/BackupAccount/BackupAccount.js
+++ b/packages/fether-react/src/BackupAccount/BackupAccount.js
@@ -91,7 +91,6 @@ class BackupAccount extends Component {
             <FetherForm.Field
               label='Password'
               onChange={this.handlePasswordChange}
-              onSubmit={this.handleSubmit}
               autoFocus
               required
               type='password'
@@ -101,10 +100,18 @@ class BackupAccount extends Component {
             <p className='error'> {message} </p>
 
             <nav className='form-nav -space-around'>
-              <button className='button -cancel' onClick={history.goBack}>
+              <button
+                className='button -cancel'
+                onClick={history.goBack}
+                type='button'
+              >
                 Back
               </button>
-              <button className='button' disabled={!password || isLoading}>
+              <button
+                className='button'
+                disabled={!password || isLoading}
+                autoFocus
+              >
                 Confirm backup
               </button>
             </nav>

--- a/packages/fether-ui/src/Form/Field/Field.js
+++ b/packages/fether-ui/src/Form/Field/Field.js
@@ -13,7 +13,6 @@ export const Field = ({
   input,
   label,
   meta,
-  autoFocus,
   ...otherProps
 }) => (
   <div className='form_field'>
@@ -30,14 +29,7 @@ export const Field = ({
       }
       position='bottom center'
       size='mini'
-      trigger={
-        <T
-          id={input && input.name}
-          {...input}
-          {...otherProps}
-          autoFocus={autoFocus}
-        />
-      }
+      trigger={<T id={input && input.name} {...input} {...otherProps} />}
     />
     {children}
   </div>

--- a/packages/fether-ui/src/Form/Field/Field.js
+++ b/packages/fether-ui/src/Form/Field/Field.js
@@ -37,12 +37,6 @@ export const Field = ({
           {...input}
           {...otherProps}
           autoFocus={autoFocus}
-          onKeyDown={event => {
-            if (event.keyCode === 13) {
-              event.preventDefault();
-              onSubmit && onSubmit();
-            }
-          }}
         />
       }
     />

--- a/packages/fether-ui/src/Form/Field/Field.js
+++ b/packages/fether-ui/src/Form/Field/Field.js
@@ -14,7 +14,6 @@ export const Field = ({
   label,
   meta,
   autoFocus,
-  onSubmit,
   ...otherProps
 }) => (
   <div className='form_field'>


### PR DESCRIPTION
@yjkimjunior Can we try and use the `onSubmit` prop on a `<form>`? I proposed here just one example on AccountName, but I think the same thing could work everywhere. I.e. don't add onSubmit on fields, but on the wrapping form. We could delete all usage of event.keycode too.

To be merged into #323 