### PR TITLE
WIP: Relates to #309. Update to Electron v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ /path/to/fether
 
 ### Dependencies
 
-Make sure you have at least `yarn` version 1.4.2 and [Node.js >=8.12.0](https://nodejs.org/en/)
+Make sure you have at least `yarn` version 1.4.2 and [Node.js >=10.11.0](https://nodejs.org/en/)
 
 ```bash
 yarn --version // Should be at least 1.4.2

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.11.0",
+  "lerna": "3.4.3",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "engines": {
-    "node": ">=8.12.0",
+    "node": ">=10.11.0",
     "yarn": "^1.4.2"
   },
   "scripts": {
@@ -62,7 +62,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "husky": "^1.0.0-rc.13",
-    "lerna": "^2.11.0",
+    "lerna": "^3.4.3",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.14.2",
     "semistandard": "^13.0.1"

--- a/packages/fether-electron/package.json
+++ b/packages/fether-electron/package.json
@@ -39,7 +39,7 @@
     "test": "echo Skipped."
   },
   "dependencies": {
-    "@parity/electron": "^3.0.1",
+    "@parity/electron": "https://github.com/paritytech/js-libs.git#luke-81-electron-3",
     "commander": "^2.15.1",
     "commander-remaining-args": "^1.2.0",
     "fether-react": "^0.2.0",
@@ -51,7 +51,7 @@
   "devDependencies": {
     "copyfiles": "^2.0.0",
     "cross-env": "^5.2.0",
-    "electron": "^2.0.2",
+    "electron": "^3.1.0",
     "electron-builder": "^20.29.0",
     "electron-webpack": "^2.1.2",
     "webpack": "^4.7.0"

--- a/packages/fether-react/package.json
+++ b/packages/fether-react/package.json
@@ -35,10 +35,10 @@
   },
   "dependencies": {
     "@craco/craco": "^3.2.3",
-    "@parity/api": "^3.0.11",
-    "@parity/contracts": "^3.0.11",
-    "@parity/light.js": "^3.0.11",
-    "@parity/light.js-react": "^3.0.11",
+    "@parity/api": "https://github.com/paritytech/js-libs.git#luke-81-electron-3",
+    "@parity/contracts": "https://github.com/paritytech/js-libs.git#luke-81-electron-3",
+    "@parity/light.js": "https://github.com/paritytech/js-libs.git#luke-81-electron-3",
+    "@parity/light.js-react": "https://github.com/paritytech/js-libs.git#luke-81-electron-3",
     "bignumber.js": "^8.0.1",
     "bip39": "^2.5.0",
     "debounce-promise": "^3.1.0",
@@ -64,10 +64,10 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "^2.1.1",
     "recompose": "^0.27.1",
-    "rxjs": "^6.2.0"
+    "rxjs": "^6.2.2"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-decorators": "^7.2.0",
+    "@babel/plugin-proposal-decorators": "^7.2.3",
     "capitalize": "^1.0.0",
     "node-sass": "^4.9.0",
     "node-sass-chokidar": "^1.2.2",


### PR DESCRIPTION
When I try to build with `yarn; yarn build` using Node.js version v11.6.0 it gives the following errors
```
scon @ ~/code/src/paritytech/fether - [luke-309-electron-3] $ yarn; yarn build
yarn install v1.12.3
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
warning " > babel-eslint@10.0.1" has unmet peer dependency "eslint@>= 4.12.1".
warning " > fether-ui@0.2.0" has unmet peer dependency "prop-types@^15.6.1".
warning " > fether-ui@0.2.0" has unmet peer dependency "react@^16.4.0".
warning "workspace-aggregator-21ff8a39-b153-439b-af1a-2c9e4c694eb4 > fether-react > react-final-form@3.6.4" has unmet peer dependency "prop-types@^15.6.0".
warning "workspace-aggregator-21ff8a39-b153-439b-af1a-2c9e4c694eb4 > fether-react > react-final-form-listeners@1.0.1" has unmet peer dependency "prop-types@^15.6.0".
warning "workspace-aggregator-21ff8a39-b153-439b-af1a-2c9e4c694eb4 > fether-ui > semantic-ui-react@0.81.3" has unmet peer dependency "react-dom@>=0.14.0 <= 16".
warning "workspace-aggregator-21ff8a39-b153-439b-af1a-2c9e4c694eb4 > fether-react > @babel/plugin-proposal-decorators > @babel/plugin-syntax-decorators@7.2.0" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "workspace-aggregator-21ff8a39-b153-439b-af1a-2c9e4c694eb4 > fether-react > @babel/plugin-proposal-decorators@7.2.3" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "workspace-aggregator-21ff8a39-b153-439b-af1a-2c9e4c694eb4 > fether-react > @babel/plugin-proposal-decorators > @babel/helper-create-class-features-plugin@7.2.3" has unmet peer dependency "@babel/core@^7.0.0".
[5/5] 📃  Building fresh packages...
[6/14] ⠐ @parity/light.js
[2/14] ⠐ @parity/electron
[7/14] ⠐ @parity/light.js-react
[4/14] ⠐ @parity/api
error /Users/scon/code/src/paritytech/fether/node_modules/@parity/light.js: Command failed.
Exit code: 1
Command: yarn build
Arguments:
Directory: /Users/scon/code/src/paritytech/fether/node_modules/@parity/light.js
Output:
yarn run v1.12.3
$ lerna exec yarn build --stream
lerna notice cli v3.10.1
lerna info Executing command in 6 packages: "yarn build"
@parity/abi: $ rimraf lib
@parity/electron: $ rimraf lib
@parity/abi: $ yarn && ./node_modules/.bin/tsc
@parity/electron: $ yarn && ./node_modules/.bin/tsc
@parity/abi: [1/5] Validating package.json...
@parity/abi: [2/5] Resolving packages...
@parity/electron: [1/5] Validating package.json...
@parity/electron: [2/5] Resolving packages...
@parity/abi: [3/5] Fetching packages...
@parity/electron: [3/5] Fetching packages...
@parity/abi: Error: ENFILE: file table overflow, open '/Users/scon/code/src/paritytech/fether/node_modules/@parity/light.js/packages/abi/package.json'
@parity/abi:     at Object.openSync (fs.js:450:3)
@parity/abi:     at Object.readFileSync (fs.js:350:35)
@parity/abi:     at onUnexpectedError (/usr/local/Cellar/yarn/1.12.3/libexec/lib/cli.js:91337:106)
@parity/abi:     at /usr/local/Cellar/yarn/1.12.3/libexec/lib/cli.js:91447:9
@parity/electron: Error: ENFILE: file table overflow, open '/Users/scon/code/src/paritytech/fether/node_modules/@parity/light.js/packages/electron/package.json'
@parity/electron:     at Object.openSync (fs.js:450:3)
@parity/electron:     at Object.readFileSync (fs.js:350:35)
@parity/electron:     at onUnexpectedError (/usr/local/Cellar/yarn/1.12.3/libexec/lib/cli.js:91337:106)
@parity/electron:     at /usr/local/Cellar/yarn/1.12.3/libexec/lib/cli.js:91447:9
@parity/abi: error Command failed with exit code 1.
@parity/abi: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn build exited 1 in '@parity/abi'

yarn run v1.12.3
$ lerna run build
lerna notice cli v3.10.1
lerna info Executing command in 3 packages: "yarn run build"
lerna info run Ran npm script 'build' in 'fether-ui' in 4.0s:
$ rimraf lib
$ babel src --out-dir lib
🎉  Successfully compiled 39 files with Babel.
lerna ERR! yarn run build exited 1 in 'fether-react'
lerna ERR! yarn run build stdout:
$ npm-run-all build-*
$ node-sass-chokidar src/ -o src/
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

lerna ERR! yarn run build stderr:
/Users/scon/code/src/paritytech/fether/node_modules/node-sass/lib/binding.js:13
      throw new Error(errors.unsupportedEnvironment());
      ^

Error: Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (67)
For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v4.9.0
    at module.exports (/Users/scon/code/src/paritytech/fether/node_modules/node-sass/lib/binding.js:13:13)
    at Object.<anonymous> (/Users/scon/code/src/paritytech/fether/node_modules/node-sass/lib/index.js:14:35)
    at Module._compile (internal/modules/cjs/loader.js:721:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:732:10)
    at Module.load (internal/modules/cjs/loader.js:620:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:560:12)
    at Function.Module._load (internal/modules/cjs/loader.js:552:3)
    at Module.require (internal/modules/cjs/loader.js:657:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/scon/code/src/paritytech/fether/node_modules/node-sass-chokidar/bin/node-sass-chokidar:18:9)
error Command failed with exit code 1.
ERROR: "build-css" exited with 1.
error Command failed with exit code 1.

lerna ERR! yarn run build exited 1 in 'fether-react'
error Command failed with exit code 1.
```