### PR TITLE
Switch to stable Parity Ethereum

### DIFF
--- a/packages/fether-electron/package.json
+++ b/packages/fether-electron/package.json
@@ -25,7 +25,7 @@
   ],
   "homepage": "https://github.com/paritytech/fether",
   "parity": {
-    "channel": "beta"
+    "channel": "stable"
   },
   "scripts": {
     "prebuild": "copyfiles -u 2 \"../fether-react/build/**/*\" static/ && ./scripts/fixElectronBug.sh",


### PR DESCRIPTION
Because I ran into https://github.com/paritytech/parity-ethereum/issues/10185 that seems to be only on beta.