### PR TITLE
fix: Fix txStatus race condition in sendStore

### DIFF
--- a/packages/fether-react/src/Send/Sent/Sent.js
+++ b/packages/fether-react/src/Send/Sent/Sent.js
@@ -145,7 +145,7 @@ class Sent extends Component {
       token
     } = this.props;
 
-    if (txStatus.confirmed) {
+    if (txStatus && txStatus.confirmed) {
       return (
         <a
           href={blockscoutTxUrl(

--- a/packages/fether-react/src/stores/sendStore.js
+++ b/packages/fether-react/src/stores/sendStore.js
@@ -75,13 +75,13 @@ export class SendStore {
 
     return new Promise((resolve, reject) => {
       send$.subscribe(txStatus => {
+        this.setTxStatus(txStatus);
         // When we arrive to the `requested` stage, we accept the request
         if (txStatus.requested) {
           this.acceptRequest(txStatus.requested, password)
             .then(resolve)
             .catch(reject);
         }
-        this.setTxStatus(txStatus);
         debug('Tx status updated.', txStatus);
       }, reject);
     });
@@ -95,11 +95,11 @@ export class SendStore {
 
     return new Promise((resolve, reject) => {
       postRaw$(this.tx.rawSigned).subscribe(txStatus => {
+        this.setTxStatus(txStatus);
         if (txStatus.signed) {
           this.listenForConfirmations();
           resolve();
         }
-        this.setTxStatus(txStatus);
         debug('Tx status updated.', txStatus);
       }, reject);
     });


### PR DESCRIPTION
Might fix https://github.com/paritytech/fether/issues/379
Previously, we would resolve the promise and then set `this.txStatus`. However, resolving the promise actually redirects to `Sent` which expects `txStatus` to already be defined