### PR TITLE
fix: Fixes #383. Restores underlay so nothing clicked upon menu blur

### DIFF
--- a/packages/fether-react/src/Tokens/Tokens.js
+++ b/packages/fether-react/src/Tokens/Tokens.js
@@ -14,6 +14,18 @@ import withAccount from '../utils/withAccount';
 @withRouter
 @withAccount
 class Tokens extends PureComponent {
+  state = {
+    isMenuOpen: false
+  };
+
+  handleMenuClose = () => {
+    this.setState({ isMenuOpen: false });
+  };
+
+  handleMenuOpen = () => {
+    this.setState({ isMenuOpen: true });
+  };
+
   isParitySignerAccount = () => {
     const {
       account: { type }
@@ -51,9 +63,11 @@ class Tokens extends PureComponent {
     const {
       account: { address, name, type }
     } = this.props;
+    const { isMenuOpen } = this.state;
 
     return (
       <div className='tokens'>
+        <div className={isMenuOpen ? 'popup-underlay' : ''} />
         <AccountHeader
           address={address}
           copyAddress
@@ -67,7 +81,10 @@ class Tokens extends PureComponent {
           right={
             <MenuPopup
               className='popup-menu-account'
+              handleMenuClose={this.handleMenuClose}
+              handleMenuOpen={this.handleMenuOpen}
               horizontalOffset={1}
+              isMenuOpen={isMenuOpen}
               menuItems={this.menuItems()}
               size='small'
               trigger={<Clickable className='icon -menu' />}

--- a/packages/fether-react/src/Tokens/Tokens.js
+++ b/packages/fether-react/src/Tokens/Tokens.js
@@ -81,11 +81,10 @@ class Tokens extends PureComponent {
           right={
             <MenuPopup
               className='popup-menu-account'
-              handleMenuClose={this.handleMenuClose}
-              handleMenuOpen={this.handleMenuOpen}
               horizontalOffset={1}
-              isMenuOpen={isMenuOpen}
               menuItems={this.menuItems()}
+              onClose={this.handleMenuClose}
+              onOpen={this.handleMenuOpen}
               size='small'
               trigger={<Clickable className='icon -menu' />}
             />

--- a/packages/fether-react/src/assets/sass/components/_popup.scss
+++ b/packages/fether-react/src/assets/sass/components/_popup.scss
@@ -1,3 +1,15 @@
+.popup-underlay {
+  background: transparent;
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1899; /* Under the menu popup */
+}
+
 .popup-menu-account {
   /* Override SUI popup styles so popup does not appear above menu icon */
   background: $white !important;

--- a/packages/fether-ui/src/MenuPopup/MenuPopup.js
+++ b/packages/fether-ui/src/MenuPopup/MenuPopup.js
@@ -7,14 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Popup as SUIPopup } from 'semantic-ui-react';
 
-export const MenuPopup = ({
-  handleMenuClose,
-  handleMenuOpen,
-  isMenuOpen,
-  menuItems,
-  ...otherProps
-}) => (
-  <SUIPopup onOpen={handleMenuOpen} onClose={handleMenuClose} {...otherProps}>
+export const MenuPopup = ({ menuItems, onClose, onOpen, ...otherProps }) => (
+  <SUIPopup onOpen={onOpen} onClose={onClose} {...otherProps}>
     <div className='popup-screen'>
       <SUIPopup.Content>
         {menuItems &&
@@ -35,7 +29,6 @@ export const MenuPopup = ({
 MenuPopup.defaultProps = {
   basic: true,
   horizontalOffset: 0,
-  isMenuOpen: false,
   on: 'click',
   size: 'large'
 };
@@ -43,12 +36,11 @@ MenuPopup.defaultProps = {
 MenuPopup.propTypes = {
   basic: PropTypes.bool, // toggles popup arrow
   className: PropTypes.string,
-  handleMenuClose: PropTypes.func,
-  handleMenuOpen: PropTypes.func,
   horizontalOffset: PropTypes.number,
-  isMenuOpen: PropTypes.bool,
   menuItems: PropTypes.array.isRequired,
   on: PropTypes.string,
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func,
   size: PropTypes.string,
   trigger: PropTypes.node
 };

--- a/packages/fether-ui/src/MenuPopup/MenuPopup.js
+++ b/packages/fether-ui/src/MenuPopup/MenuPopup.js
@@ -7,8 +7,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Popup as SUIPopup } from 'semantic-ui-react';
 
-export const MenuPopup = ({ menuItems, ...otherProps }) => (
-  <SUIPopup {...otherProps}>
+export const MenuPopup = ({
+  handleMenuClose,
+  handleMenuOpen,
+  isMenuOpen,
+  menuItems,
+  ...otherProps
+}) => (
+  <SUIPopup onOpen={handleMenuOpen} onClose={handleMenuClose} {...otherProps}>
     <div className='popup-screen'>
       <SUIPopup.Content>
         {menuItems &&
@@ -29,6 +35,7 @@ export const MenuPopup = ({ menuItems, ...otherProps }) => (
 MenuPopup.defaultProps = {
   basic: true,
   horizontalOffset: 0,
+  isMenuOpen: false,
   on: 'click',
   size: 'large'
 };
@@ -36,7 +43,10 @@ MenuPopup.defaultProps = {
 MenuPopup.propTypes = {
   basic: PropTypes.bool, // toggles popup arrow
   className: PropTypes.string,
+  handleMenuClose: PropTypes.func,
+  handleMenuOpen: PropTypes.func,
   horizontalOffset: PropTypes.number,
+  isMenuOpen: PropTypes.bool,
   menuItems: PropTypes.array.isRequired,
   on: PropTypes.string,
   size: PropTypes.string,


### PR DESCRIPTION
When the menu is open and you click away from the menu (blur) to close it, then previously if your blur click was on a button then it would recognise the blur as being a click on a button that just so happened to be where you randomly clicked. 

Now when you blur click there is an underlay that absorbs the blur click and disappears again until the menu is opened again