### PR TITLE
fix: Fixes #408 window resize by converting args[0] height to integer for setContentSize

### DIFF
--- a/packages/fether-electron/src/main/app/messages/index.js
+++ b/packages/fether-electron/src/main/app/messages/index.js
@@ -19,16 +19,22 @@ export default async (fetherAppWindow, event, action, ...args) => {
     }
     switch (action) {
       case 'app-resize': {
+        if (!args[0]) {
+          return;
+        }
         const [width] = fetherAppWindow.getContentSize();
-        const newHeight = args[0];
+        // Conversion to integer is required to pass as argument to setContentSize.
+        // Reference: https://electronjs.org/docs/all#winsetcontentsizewidth-height-animate
+        const newHeight = parseInt(args[0]);
         const feedbackButtonHeight = 20;
         const resizeHeight = newHeight + 2;
         const height =
           process.platform === 'win32' && fetherAppWindow.isMenuBarVisible()
             ? resizeHeight + feedbackButtonHeight
             : resizeHeight;
+        const resizeWithAnimation = true;
 
-        fetherAppWindow.setContentSize(width, height);
+        fetherAppWindow.setContentSize(width, height, resizeWithAnimation);
         break;
       }
       case 'check-clock-sync': {


### PR DESCRIPTION
Note that in addition to resolving the bug, this PR introduces an animation (supported only on macOS) when the window resizes