### PR TITLE
refactor: Don't call transactionCountOf$ until needed

### DIFF
--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -15,7 +15,7 @@ import { inject, observer } from 'mobx-react';
 import { isAddress } from '@parity/api/lib/util/address';
 import light from '@parity/light.js-react';
 import { Link } from 'react-router-dom';
-import { map, startWith, delay, tap } from 'rxjs/operators';
+import { startWith } from 'rxjs/operators';
 import { OnChange } from 'react-final-form-listeners';
 import { withProps } from 'recompose';
 
@@ -49,7 +49,7 @@ const MIN_GAS_PRICE = 3; // Safelow gas price from GasStation, in Gwei
     transactionCountOf$(address).pipe(startWith(undefined))
 })
 @withBalance // Balance of current token (can be ETH)
-@withEthBalance
+@withEthBalance // ETH balance
 @observer
 class TxForm extends Component {
   state = {
@@ -243,7 +243,8 @@ class TxForm extends Component {
                       <form className='send-form' onSubmit={handleSubmit}>
                         <fieldset className='form_fields'>
                           {/* Unfortunately, we need to set these hidden fields
-                              for the 3 values that come from props. */}
+                              for the 3 values that come from props, even
+                              though they are already set in initialValues. */}
                           <Field name='chainId' render={() => null} />
                           <Field name='ethBalance' render={() => null} />
                           <Field name='transactionCount' render={() => null} />
@@ -418,7 +419,6 @@ class TxForm extends Component {
 
     try {
       const { token } = this.props;
-      const { chainId, ethBalance, transactionCount } = values;
 
       const preValidation = this.preValidate(values);
 
@@ -431,15 +431,15 @@ class TxForm extends Component {
       // come from props, and are passed into `values` via the form's
       // initialValues. As such, they don't have visible fields, so putting an
       // error here just means we're keeping the form state as not valid.
-      if (!chainId) {
+      if (!values.chainId) {
         return { chainId: 'Fetching chainId' };
       }
 
-      if (!ethBalance) {
+      if (!values.ethBalance) {
         return { ethBalance: 'Fetching ethBalance' };
       }
 
-      if (!transactionCount) {
+      if (!values.transactionCount) {
         return {
           transactionCount: 'Fetching transactionCount'
         };
@@ -459,7 +459,7 @@ class TxForm extends Component {
       if (
         this.estimatedTxFee(values)
           .plus(token.address === 'ETH' ? toWei(values.amount) : 0)
-          .gt(toWei(ethBalance))
+          .gt(toWei(values.ethBalance))
       ) {
         return token.address !== 'ETH'
           ? { amount: 'ETH balance too low to pay for gas' }

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -364,7 +364,7 @@ class TxForm extends Component {
     );
   }
 
-  renderNull = this.renderNull;
+  renderNull = () => null;
 
   /**
    * Prevalidate form on user's input. These validations are sync.

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -451,7 +451,7 @@ class TxForm extends Component {
       }
 
       if (values.gas && values.gas.eq(-1)) {
-        return {};
+        return { amount: 'Unable to estimate gas...' };
       }
 
       // If the gas hasn't been calculated yet, then we don't show any errors,

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -245,9 +245,12 @@ class TxForm extends Component {
                           {/* Unfortunately, we need to set these hidden fields
                               for the 3 values that come from props, even
                               though they are already set in initialValues. */}
-                          <Field name='chainId' render={() => null} />
-                          <Field name='ethBalance' render={() => null} />
-                          <Field name='transactionCount' render={() => null} />
+                          <Field name='chainId' render={this.renderNull} />
+                          <Field name='ethBalance' render={this.renderNull} />
+                          <Field
+                            name='transactionCount'
+                            render={this.renderNull}
+                          />
 
                           <Field
                             as='textarea'
@@ -360,6 +363,8 @@ class TxForm extends Component {
       </div>
     );
   }
+
+  renderNull = this.renderNull;
 
   /**
    * Prevalidate form on user's input. These validations are sync.

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -461,7 +461,8 @@ class TxForm extends Component {
 
       if (values.gas && values.gas.eq(-1)) {
         debug('Unable to estimate gas...');
-        return { gas: 'Unable to estimate gas...' };
+        // Show this error on the `amount` field
+        return { amount: 'Unable to estimate gas...' };
       }
 
       if (!this.isEstimatedTxFee(values)) {

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -15,8 +15,8 @@ import { inject, observer } from 'mobx-react';
 import { isAddress } from '@parity/api/lib/util/address';
 import light from '@parity/light.js-react';
 import { Link } from 'react-router-dom';
-import { startWith } from 'rxjs/operators';
 import { OnChange } from 'react-final-form-listeners';
+import { startWith } from 'rxjs/operators';
 import { withProps } from 'recompose';
 
 import { estimateGas } from '../../utils/transaction';

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -434,28 +434,24 @@ class TxForm extends Component {
 
       // The 3 values below (`chainId`, `ethBalance`, and `transactionCount`)
       // come from props, and are passed into `values` via the form's
-      // initialValues. As such, they don't have visible fields, so putting an
-      // error here just means we're keeping the form state as not valid.
+      // initialValues. As such, they don't have visible fields, so we put
+      // their errors in the `amount` field arbitrarily.
       if (!values.chainId) {
-        return { chainId: 'Fetching chainId' };
+        return { amount: 'Fetching chain ID' };
       }
 
       if (!values.ethBalance) {
-        return { ethBalance: 'Fetching ethBalance' };
+        return { amount: 'Fetching Ether balance' };
       }
 
       if (!values.transactionCount) {
-        return {
-          transactionCount: 'Fetching transactionCount'
-        };
+        return { amount: 'Fetching transaction count for nonce' };
       }
 
       if (values.gas && values.gas.eq(-1)) {
         return { amount: 'Unable to estimate gas...' };
       }
 
-      // If the gas hasn't been calculated yet, then we don't show any errors,
-      // just wait a bit more
       if (!this.isEstimatedTxFee(values)) {
         return { amount: 'Estimating gas...' };
       }

--- a/packages/fether-react/src/Tokens/TokensList/TokenBalance/TokenBalance.js
+++ b/packages/fether-react/src/Tokens/TokensList/TokenBalance/TokenBalance.js
@@ -18,17 +18,8 @@ import withBalance from '../../../utils/withBalance';
 @inject('sendStore')
 class TokenBalance extends Component {
   static propTypes = {
-    hideLoadingAccountTokensModal: PropTypes.func,
     token: PropTypes.object
   };
-
-  componentDidMount () {
-    const { hideLoadingAccountTokensModal } = this.props;
-
-    if (hideLoadingAccountTokensModal) {
-      hideLoadingAccountTokensModal();
-    }
-  }
 
   handleClick = () => {
     const {

--- a/packages/fether-react/src/Tokens/TokensList/TokensList.js
+++ b/packages/fether-react/src/Tokens/TokensList/TokensList.js
@@ -4,37 +4,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import React, { Component } from 'react';
-import { Modal } from 'fether-ui';
 import RequireHealthOverlay from '../../RequireHealthOverlay';
 import TokenBalance from './TokenBalance';
 import withTokens from '../../utils/withTokens';
-import loading from '../../assets/img/icons/loading.svg';
 
 @withTokens
 class TokensList extends Component {
-  state = {
-    isLoadingAccountTokens: true
-  };
-
-  hideLoadingAccountTokensModal = () => {
-    this.setState({ isLoadingAccountTokens: false });
-  };
-
   render () {
     const { tokensArray } = this.props;
-    const { isLoadingAccountTokens } = this.state;
     // Show empty token placeholder if tokens have not been loaded yet
     const shownArray = tokensArray.length ? tokensArray : [{}];
 
     return (
       <RequireHealthOverlay require='sync'>
-        <Modal
-          description='Please wait...'
-          fullscreen={false}
-          icon={loading}
-          title='Loading account tokens...'
-          visible={isLoadingAccountTokens}
-        />
         <div className='window_content'>
           <div className='box -scroller'>
             <ul className='list -padded'>
@@ -43,12 +25,7 @@ class TokensList extends Component {
                 index // With empty tokens, the token.address is not defined, so we prefix with index
               ) => (
                 <li key={`${index}-${token.address}`}>
-                  <TokenBalance
-                    hideLoadingAccountTokensModal={
-                      this.hideLoadingAccountTokensModal
-                    }
-                    token={token}
-                  />
+                  <TokenBalance token={token} />
                 </li>
               ))}
             </ul>

--- a/packages/fether-react/src/index.js
+++ b/packages/fether-react/src/index.js
@@ -16,7 +16,7 @@ import rootStore from './stores';
 import './index.css';
 
 // Show debug logs
-window.localStorage.debug = 'fether*'; // https://github.com/visionmedia/debug#browser-support
+window.localStorage.debug = 'fether*,@parity*'; // https://github.com/visionmedia/debug#browser-support
 
 // Set recompose to use RxJS
 // https://github.com/acdlite/recompose/blob/master/docs/API.md#setobservableconfig

--- a/packages/fether-react/src/utils/withAccount.js
+++ b/packages/fether-react/src/utils/withAccount.js
@@ -6,24 +6,14 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
 import { compose, mapProps } from 'recompose';
-import { startWith } from 'rxjs/operators';
-import light from '@parity/light.js-react';
-import { transactionCountOf$ } from '@parity/light.js';
 
 import withAccountsInfo from '../utils/withAccountsInfo';
 
 const WithAccount = compose(
   withRouter,
   withAccountsInfo,
-  light({
-    transactionCount: props =>
-      transactionCountOf$(props.match.params.accountAddress).pipe(
-        startWith(undefined)
-      )
-  }),
   mapProps(
     ({
-      transactionCount,
       match: {
         params: { accountAddress }
       },
@@ -33,8 +23,7 @@ const WithAccount = compose(
       account: {
         address: accountAddress,
         name: accountsInfo[accountAddress].name,
-        type: accountsInfo[accountAddress].type,
-        transactionCount
+        type: accountsInfo[accountAddress].type
       },
       ...otherProps
     })

--- a/packages/fether-react/src/utils/withBalance.js
+++ b/packages/fether-react/src/utils/withBalance.js
@@ -9,19 +9,25 @@ import branch from 'recompose/branch';
 import compose from 'recompose/compose';
 import { fromWei } from '@parity/api/lib/util/wei';
 import light from '@parity/light.js-react';
-import { map } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import withProps from 'recompose/withProps';
 
 export const withErc20Balance = light({
   erc20Balance: ({ token, account: { address } }) =>
     makeContract(token.address, abi)
       .balanceOf$(address)
-      .pipe(map(value => value && value.div(10 ** token.decimals)))
+      .pipe(
+        map(value => value && value.div(10 ** token.decimals)),
+        startWith(undefined)
+      )
 });
 
 export const withEthBalance = light({
   ethBalance: ({ account: { address } }) =>
-    balanceOf$(address).pipe(map(value => value && fromWei(value)))
+    balanceOf$(address).pipe(
+      map(value => value && fromWei(value)),
+      startWith(undefined)
+    )
 });
 
 /**


### PR DESCRIPTION
Only the TxForm component needs the transaction count, so we don't make additional RPC calls on other screens.

fixes #420. It makes the overall transitions between screens quicker.