### PR TITLE
fix: Fresh sync shows blank screen

### DIFF
--- a/packages/fether-react/src/App/App.js
+++ b/packages/fether-react/src/App/App.js
@@ -18,6 +18,7 @@ import ReactResizeDetector from 'react-resize-detector';
 import Accounts from '../Accounts';
 import BackupAccount from '../BackupAccount';
 import Onboarding from '../Onboarding';
+import RequireHealthOverlay from '../RequireHealthOverlay';
 import Send from '../Send';
 import Tokens from '../Tokens';
 import Whitelist from '../Whitelist';
@@ -48,21 +49,21 @@ class App extends Component {
       parityStore: { api }
     } = this.props;
 
-    // The child components make use of light.js and light.js needs to be passed
-    // an API first, otherwise it will throw an error.
-    // We set parityStore.api right after we set the API for light.js, so we
-    // verify here that parityStore.api is defined, and if not we don't render
-    // the children.
-    if (!api) {
-      return null;
-    }
-
     if (isFirstRun) {
       return (
         <div className='window'>
           <Onboarding />
         </div>
       );
+    }
+
+    // The child components make use of light.js and light.js needs to be passed
+    // an API first, otherwise it will throw an error.
+    // We set parityStore.api right after we set the API for light.js, so we
+    // verify here that parityStore.api is defined, and if not we don't render
+    // the children.
+    if (!api) {
+      return <RequireHealthOverlay fullscreen require='node' />;
     }
 
     return (

--- a/packages/fether-react/src/App/App.js
+++ b/packages/fether-react/src/App/App.js
@@ -61,9 +61,18 @@ class App extends Component {
     // an API first, otherwise it will throw an error.
     // We set parityStore.api right after we set the API for light.js, so we
     // verify here that parityStore.api is defined, and if not we don't render
-    // the children.
+    // the children, just a <RequireHealthOverlay />.
     if (!api) {
-      return <RequireHealthOverlay fullscreen require='node' />;
+      return (
+        <ReactResizeDetector handleHeight onResize={this.handleResize}>
+          <RequireHealthOverlay fullscreen require='node'>
+            {/* Adding these components to have minimum height on window */}
+            <div className='content'>
+              <div className='window' />
+            </div>
+          </RequireHealthOverlay>
+        </ReactResizeDetector>
+      );
     }
 
     return (

--- a/packages/fether-react/src/Health/Health.js
+++ b/packages/fether-react/src/Health/Health.js
@@ -58,7 +58,7 @@ class Health extends Component {
     } = this.props;
 
     if (status.downloading) {
-      return `Downloading Parity Ethereum... (${
+      return `Downloading Parity Ethereum (${
         payload.downloading.syncPercentage
       }%)`;
     } else if (status.launching) {

--- a/packages/fether-react/src/Health/Health.js
+++ b/packages/fether-react/src/Health/Health.js
@@ -13,9 +13,9 @@ import withHealth from '../utils/withHealth';
 @branch(
   ({
     health: {
-      status: { nodeConnected, syncing }
+      status: { good, syncing }
     }
-  }) => nodeConnected || syncing,
+  }) => good || syncing,
   // Only call light.js chainName$ if we're syncing or good
   light({
     chainName: () => chainName$().pipe(withoutLoading())

--- a/packages/fether-react/src/Health/Health.js
+++ b/packages/fether-react/src/Health/Health.js
@@ -4,15 +4,23 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import React, { Component } from 'react';
-
+import { branch } from 'recompose';
 import { chainName$, withoutLoading } from '@parity/light.js';
 import light from '@parity/light.js-react';
 import withHealth from '../utils/withHealth';
 
-@light({
-  chainName: () => chainName$().pipe(withoutLoading())
-})
 @withHealth
+@branch(
+  ({
+    health: {
+      status: { nodeConnected, syncing }
+    }
+  }) => nodeConnected || syncing,
+  // Only call light.js chainName$ if we're syncing or good
+  light({
+    chainName: () => chainName$().pipe(withoutLoading())
+  })
+)
 class Health extends Component {
   render () {
     return (
@@ -49,18 +57,18 @@ class Health extends Component {
       chainName
     } = this.props;
 
-    if (!status.nodeConnected && !status.internet) {
-      return 'No internet. No node connected';
-    } else if (!status.nodeConnected && status.internet) {
-      return 'Connecting to node...';
-    } else if (status.nodeConnected && !status.internet) {
-      return 'No internet. Connected to node';
-    } else if (status.downloading) {
+    if (status.downloading) {
       return `Downloading Parity Ethereum... (${
         payload.downloading.syncPercentage
       }%)`;
     } else if (status.launching) {
       return 'Launching the node...';
+    } else if (!status.nodeConnected && !status.internet) {
+      return 'No internet. No node connected';
+    } else if (!status.nodeConnected && status.internet) {
+      return 'Connecting to node...';
+    } else if (status.nodeConnected && !status.internet) {
+      return 'No internet. Connected to node';
     } else if (!status.clockSync) {
       return 'Clock of host not in sync';
     } else if (!status.peers) {

--- a/packages/fether-react/src/RequireHealthOverlay/HealthModal/HealthModal.js
+++ b/packages/fether-react/src/RequireHealthOverlay/HealthModal/HealthModal.js
@@ -8,14 +8,22 @@ import PropTypes from 'prop-types';
 import { chainName$, withoutLoading } from '@parity/light.js';
 import light from '@parity/light.js-react';
 import { Modal } from 'fether-ui';
+import { of } from 'rxjs';
 
 import withHealth from '../../utils/withHealth';
 import loading from '../../assets/img/icons/loading.svg';
 
-@light({
-  chainName: () => chainName$().pipe(withoutLoading())
-})
 @withHealth
+@light({
+  chainName: ({
+    health: {
+      status: { nodeConnected }
+    }
+  }) => {
+    // Only call chainName$ if we're connected to the node
+    return nodeConnected ? chainName$().pipe(withoutLoading()) : of('');
+  }
+})
 class HealthModal extends Component {
   static propTypes = {
     chainName: PropTypes.string,

--- a/packages/fether-react/src/utils/withHealth.js
+++ b/packages/fether-react/src/utils/withHealth.js
@@ -127,21 +127,20 @@ export default compose(
         ]) => {
           const isDownloading =
             online && downloadProgress > 0 && !isParityRunning;
-          const isNodeConnected =
-            !isDownloading && isApiConnected && isParityRunning;
-          const isNoPeers = peerCount === undefined || peerCount.lte(1);
+          const isNoPeers =
+            isApiConnected && (peerCount === undefined || peerCount.lte(1));
           const isGood =
-            isSync && !isNoPeers && isClockSync && isNodeConnected && online;
+            isSync && !isNoPeers && isClockSync && isApiConnected && online;
 
           // Status - list of all states of health store
           const status = {
             internet: online, // Internet connection
-            nodeConnected: isNodeConnected, // Connected to local Parity Ethereum node
+            nodeConnected: isApiConnected, // Connected to local Parity Ethereum node
             clockSync: isClockSync, // Local clock is not synchronised
             downloading: isDownloading, // Currently downloading Parity Ethereum
             launching: !isApiConnected, // Launching Parity Ethereum only upon startup
             peers: !isNoPeers, // Connecion to peer nodes
-            syncing: !isSync, // Synchronising blocks
+            syncing: isApiConnected && !isSync, // Synchronising blocks
             good: isGood // Synchronised and no issues
           };
 


### PR DESCRIPTION
To test:
- Fresh install `rm -rf ~/Library{Application Support/{io.parity.ethereum | Electron | fether}`
- yarn electron

On master, #416 introduced a bug where, on fresh launch, a blank screen was shown (because of [these lines](https://github.com/paritytech/fether/blob/ebb39a444c69df5bc908a20bc42fc78768a2ebb5/packages/fether-react/src/App/App.js#L56-L58)).

This PR basically just replaces this `null` with a `RequireHealthOverlay`.

Moreover, `<Health>` and `<HealthModal>` (both can be rendered before api is defined) use light.js's `chainName$` when syncing/synced, but we only allow calling this method when the api is connected.