### PR TITLE
fix: Relates to #429. Fether menu toggles on Windows and Linux Mint with ALT

### DIFF
--- a/packages/fether-electron/src/main/app/messages/index.js
+++ b/packages/fether-electron/src/main/app/messages/index.js
@@ -29,7 +29,8 @@ export default async (fetherAppWindow, event, action, ...args) => {
         const feedbackButtonHeight = 20;
         const resizeHeight = newHeight + 2;
         const height =
-          process.platform === 'win32' && fetherAppWindow.isMenuBarVisible()
+          (process.platform === 'win32' || process.platform === 'linux') &&
+          fetherAppWindow.isMenuBarVisible()
             ? resizeHeight + feedbackButtonHeight
             : resizeHeight;
 

--- a/packages/fether-electron/src/main/app/messages/index.js
+++ b/packages/fether-electron/src/main/app/messages/index.js
@@ -26,12 +26,12 @@ export default async (fetherAppWindow, event, action, ...args) => {
         // Conversion to integer is required to pass as argument to setContentSize.
         // Reference: https://electronjs.org/docs/all#winsetcontentsizewidth-height-animate
         const newHeight = parseInt(args[0]);
-        const feedbackButtonHeight = 20;
+        const menuHeight = 20;
         const resizeHeight = newHeight + 2;
         const height =
           (process.platform === 'win32' || process.platform === 'linux') &&
           fetherAppWindow.isMenuBarVisible()
-            ? resizeHeight + feedbackButtonHeight
+            ? resizeHeight + menuHeight
             : resizeHeight;
 
         fetherAppWindow.setContentSize(width, height);

--- a/packages/fether-electron/src/main/app/methods/setupMenu.js
+++ b/packages/fether-electron/src/main/app/methods/setupMenu.js
@@ -13,12 +13,16 @@ function setupMenu (fetherApp) {
   addMenu();
 
   /**
-   * Toggle the Fether menu bar in the frame.
-   * If not shown by default then when shown it may crop the bottom
-   * of the window when menu open/close toggled on Windows.
+   * Note that the Fether window must be configured with a "frame"
+   * on Windows 10 or Linux Mint. If you configure `setAutoHideMenuBar(false)`
+   * and `setMenuBarVisibility(true)` then the menu does not auto-hide and
+   * you may not toggle the Fether window to be shown/hidden.
+   * However, if you configure `setAutoHideMenuBar(true)`
+   * and `setMenuBarVisibility(false)` then you may toggle the Fether window
+   * to be shown/hidden in the frame by pressing or holding one of the ALT keys.
    */
-  fetherApp.win.setAutoHideMenuBar(false); // Pressing ALT shows menu bar
-  fetherApp.win.setMenuBarVisibility(true);
+  fetherApp.win.setAutoHideMenuBar(true); // Pressing ALT shows menu bar
+  fetherApp.win.setMenuBarVisibility(false);
 
   pino.info('Finished configuring Electron menu');
 }

--- a/packages/fether-electron/src/main/app/options/config/index.js
+++ b/packages/fether-electron/src/main/app/options/config/index.js
@@ -40,7 +40,10 @@ if (process.platform === 'win32') {
   );
 }
 
-const shouldUseFrame = process.platform === 'win32';
+// Fether window must have a "frame" otherwise the menu
+// does not appear on Windows 10 or Linux Mint
+const shouldUseFrame =
+  process.platform === 'win32' || process.platform === 'linux';
 
 const windowPosition =
   process.platform === 'win32' ? 'trayBottomCenter' : 'trayCenter';


### PR DESCRIPTION
I've pushed a commit that makes the Fether window have a "frame" on Linux, and enables auto-hide so the user can toggle the menu to show/hide by pressing the ALT key.

Note that I think we need a usage guide (see related comment here https://github.com/paritytech/fether/pull/400#issuecomment-465363423) where we highlight that pressing ALT toggles the menu on Linux and Windows, whereas doing so is not necessary on macOS. Particularly since the tray balloon popup that appears and points out to the user that they can toggle the Fether menu by pressing ALT is an Electron feature that is only supported on Windows.

Bug: Toggling the menu by pressing ALT does not appear to correctly modify the window height in
fether-electron/src/main/app/messages/index.js so the bottom of the window's contents isn't cropped when the menu is shown
