### PR TITLE
fix: Fixes cannot getContent of undefined bug when run TASKBAR=false and Close Window then re-open it

### DIFF
--- a/packages/fether-electron/src/main/app/messages/index.js
+++ b/packages/fether-electron/src/main/app/messages/index.js
@@ -19,7 +19,7 @@ export default async (fetherAppWindow, event, action, ...args) => {
     }
     switch (action) {
       case 'app-resize': {
-        if (!args[0]) {
+        if (!fetherAppWindow || !args[0]) {
           return;
         }
         const [width] = fetherAppWindow.getContentSize();


### PR DESCRIPTION
* When you run `yarn; TASKBAR=false yarn start` and then choose from Fether menu  "Window > Close Window" and then re-open it by clicking the dock icon on macOS it gives error Cannot getContentSize of undefined, this resolves the issue