### PR TITLE
fix: Fixes #421. Linux tray and dock icon not pixelated and Fether branding

### DIFF
--- a/packages/fether-electron/src/main/app/options/config/index.js
+++ b/packages/fether-electron/src/main/app/options/config/index.js
@@ -17,7 +17,7 @@ const INDEX_HTML_PATH =
   });
 
 // Icon path differs when started with `yarn electron` or `yarn start`
-let iconPath = path.join(staticPath, 'assets', 'icons', 'icon.png');
+let iconPath = path.join(staticPath, 'assets', 'icons', 'mac', 'iconDock.png');
 let iconDockPath = '';
 
 if (process.platform === 'win32') {


### PR DESCRIPTION
I think this actually restores it the way is once was

Screenshot on Linux Mint

<img width="468" alt="screen shot 2019-02-23 at 5 30 39 pm" src="https://user-images.githubusercontent.com/6226175/53289034-d8956b00-3790-11e9-944b-8cc499f63e17.png">
