### PR TITLE
feat: Add Reload to taskbar menu in development only

### DIFF
--- a/packages/fether-electron/src/main/app/menu/template/index.js
+++ b/packages/fether-electron/src/main/app/menu/template/index.js
@@ -156,7 +156,7 @@ const getMenubarMenuTemplate = fetherApp => {
 
 const getContextTrayMenuTemplate = fetherApp => {
   if (fetherApp.options.withTaskbar) {
-    const template = [
+    let template = [
       {
         label: 'Show/Hide Fether',
         click () {
@@ -167,9 +167,17 @@ const getContextTrayMenuTemplate = fetherApp => {
             fetherApp.win.focus();
           }
         }
-      },
-      { label: 'Quit', role: 'quit' }
+      }
     ];
+
+    if (process.env.NODE_ENV !== 'production') {
+      template.push({
+        label: 'Reload',
+        click: () => fetherApp.win.webContents.reload()
+      });
+    }
+
+    template.push({ label: 'Quit', role: 'quit' });
 
     return template;
   }

--- a/packages/fether-electron/src/main/app/menu/template/index.js
+++ b/packages/fether-electron/src/main/app/menu/template/index.js
@@ -116,7 +116,7 @@ const getMenubarMenuTemplate = fetherApp => {
     ]
   };
 
-  let template = [
+  const template = [
     fileTab,
     process.platform === 'darwin' ? editTabMacOS : editTab,
     process.platform === 'win32' ? viewTabWindowsOS : viewTab,
@@ -156,7 +156,7 @@ const getMenubarMenuTemplate = fetherApp => {
 
 const getContextTrayMenuTemplate = fetherApp => {
   if (fetherApp.options.withTaskbar) {
-    let template = [
+    const template = [
       {
         label: 'Show/Hide Fether',
         click () {
@@ -184,7 +184,7 @@ const getContextTrayMenuTemplate = fetherApp => {
 };
 
 const getContextWindowMenuTemplate = fetherApp => {
-  let template = getMenubarMenuTemplate(fetherApp);
+  const template = getMenubarMenuTemplate(fetherApp);
 
   if (fetherApp.options.withTaskbar) {
     // Remove File and Help menus in taskbar mode for window context menu


### PR DESCRIPTION
In the development environment only, when running Fether with `yarn start`, we have a known issue where a blank screen appears and we have to reload the window. On macOS and some Linux OS this is not an issue when the taskbar menu is available. However on Windows, there is no taskbar menu, so there user cannot choose "Reload" from the menu, since the menu that's shown upon right-click in the Fether window is only available in development after reloading the window.

As discussed with @Tbaut, propose to add "Reload" as an item to the menu that's show when you click the taskbar icon, so it will now show:

**development**

Show/Hide Fether
Reload
Quit

**production**

Show/Hide Fether
Quit

