### PR TITLE
Center account header 

### DIFF
--- a/packages/fether-react/src/assets/sass/components/_account.scss
+++ b/packages/fether-react/src/assets/sass/components/_account.scss
@@ -41,7 +41,7 @@
     padding-bottom: 0.1rem;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: 230px;
+    max-width: 210px;
 
     /**
      * Information component when used with components


### PR DESCRIPTION
closes #469

I've reduced the size 230->210px so that the hover on account copy looks good:
![image](https://user-images.githubusercontent.com/33178835/54626645-e083ba80-4a71-11e9-940f-5b8c134be919.png)
instead of 
![image](https://user-images.githubusercontent.com/33178835/54626734-14f77680-4a72-11e9-8754-c91194533de8.png)

