### PR TITLE
fix: correctly set permissions on downloaded binary

### DIFF
--- a/scripts/fetch-latest-parity.js
+++ b/scripts/fetch-latest-parity.js
@@ -125,7 +125,7 @@ function downloadParity () {
           // Write to file and set a+x permissions
           const destinationPath = `${STATIC_DIRECTORY}/${name}`;
           return fsWriteFile(destinationPath, data)
-            .then(() => fsChmod(destinationPath, 755))
+            .then(() => fsChmod(destinationPath, 0o755))
             .then(() => destinationPath);
         });
       })

--- a/scripts/fetch-latest-parity.js
+++ b/scripts/fetch-latest-parity.js
@@ -125,7 +125,7 @@ function downloadParity () {
           // Write to file and set a+x permissions
           const destinationPath = `${STATIC_DIRECTORY}/${name}`;
           return fsWriteFile(destinationPath, data)
-            .then(() => fsChmod(destinationPath, 0o755))
+            .then(() => fsChmod(destinationPath, 0o755)) // https://nodejs.org/api/fs.html#fs_fs_chmod_path_mode_callback
             .then(() => destinationPath);
         });
       })


### PR DESCRIPTION
Thanks to @fevo1971 for finding this!

https://gitlab.parity.io/parity/fether/-/jobs/132028
the permission of the downloaded binary was:
```
--wxrw--wt  1 administrator  staff  46128528 Mar 21 18:13 parity
```
We need to use octals to make it work cross-platform: https://nodejs.org/api/fs.html#fs_fs_chmod_path_mode_callback