### PR TITLE
Convert the gasPrice to Gwei for Parity Signer transactions

### DIFF
--- a/packages/fether-react/src/utils/transaction.js
+++ b/packages/fether-react/src/utils/transaction.js
@@ -131,7 +131,7 @@ const getEthereumTx = tx => {
   const txParams = {
     nonce: '0x' + transactionCount.toNumber().toString(16),
     gasLimit: '0x' + gas.toNumber().toString(16),
-    gasPrice,
+    gasPrice: toWei(gasPrice, 'shannon').toNumber(),
     chainId
   };
 


### PR DESCRIPTION
Transactions made using a Parity Signer accounts had a very low gas price. We usually deal with price in Gwei (also in the sendstore) until we send the tx. This conversion step was forgotten for Signer accounts.
closes https://github.com/paritytech/fether/issues/456