### PR TITLE
Make sure long token names don't break the UI

### DIFF
--- a/packages/fether-react/src/assets/sass/components/_header-nav.scss
+++ b/packages/fether-react/src/assets/sass/components/_header-nav.scss
@@ -40,6 +40,10 @@
       line-height: ms(0) * 0.8;
       color: rgba($black, 0.675);
       font-weight: 500;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-width: 15rem;
+      white-space: nowrap;
     }
   }
 

--- a/packages/fether-react/src/assets/sass/components/_token.scss
+++ b/packages/fether-react/src/assets/sass/components/_token.scss
@@ -17,6 +17,7 @@
     justify-content: center;
     align-items: center;
     align-content: center;
+    flex: 1;
 
     img {
       display: block;
@@ -32,12 +33,18 @@
     flex-grow: 1;
     color: $black;
     font-weight: 500;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    flex: 4;
   }
 
   .token_balance {
     font-family: $mono;
     color: $grey;
     height: ms(0) * 1.3;
+    flex: 3;
+    text-align: right;
   }
 
   .token_symbol {


### PR DESCRIPTION
Some test tokens (kovan with the new token list) have very long names and "broke" the UI
![image](https://user-images.githubusercontent.com/33178835/55092273-8f4b7a80-50b2-11e9-8760-8c8795c0dde5.png)
![image](https://user-images.githubusercontent.com/33178835/55092315-ac804900-50b2-11e9-8c53-58b6cf6976ec.png)


It would now look like this:
![image](https://user-images.githubusercontent.com/33178835/55092137-50b5c000-50b2-11e9-8331-0a3882094959.png)
![image](https://user-images.githubusercontent.com/33178835/55092148-57443780-50b2-11e9-8fca-464fc009fbee.png)
