### PR TITLE
Use atomiclabs/cryptocurrency-icons/ set of icons

### DIFF
--- a/packages/fether-react/src/assets/tokens/foundation.json
+++ b/packages/fether-react/src/assets/tokens/foundation.json
@@ -3,21 +3,21 @@
     "address": "0x3a1Bda28AdB5B0a812a7CF10A1950c920F79BcD3",
     "symbol": "FLP",
     "decimals": 18,
-    "name": "FLIP Token",
-    "logo": "https://tokensale.gameflip.com/img/ico/flip_logo_64x64.png"
+    "name": "FLIP Token"
   },
   {
     "address": "0x08d32b0da63e2C3bcF8019c9c5d849d7a9d791e6",
     "symbol": "DCN",
     "decimals": 0,
     "name": "Dentacoin",
-    "logo": "https://dentacoin.com/web/img/DCNlogo.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dcn%402x.png"
   },
   {
     "address": "0x48f775EFBE4F5EcE6e0DF2f7b5932dF56823B990",
     "symbol": "R",
     "decimals": 0,
-    "name": "Revain"
+    "name": "Revain",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/r%402x.png"
   },
   {
     "address": "0x1D4cCC31dAB6EA20f461d329a0562C1c58412515",
@@ -35,15 +35,13 @@
     "address": "0xAEA1C18A992984831002D0cf90E291FB52d72649",
     "symbol": "ECP (ECRYPTO COIN)",
     "decimals": 18,
-    "name": "ECRYPTO COIN",
-    "logo": "https://ecryptotokens.com/images/resources/logo.png"
+    "name": "ECRYPTO COIN"
   },
   {
     "address": "0x8869b1F9bC8B246a4D7220F834E56ddfdd8255E7",
     "symbol": "ECP (ECrypto Coin)",
     "decimals": 18,
-    "name": "ECrypto Coin",
-    "logo": "https://ecryptotokens.com/images/resources/logo.png"
+    "name": "ECrypto Coin"
   },
   {
     "address": "0x6758B7d441a9739b98552B373703d8d3d14f9e62",
@@ -55,20 +53,21 @@
     "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
     "symbol": "MKR",
     "decimals": 18,
-    "name": "MakerDAO"
+    "name": "MakerDAO",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mkr%402x.png"
   },
   {
     "address": "0x28B94F58B11aC945341329dBf2e5EF7F8Bd44225",
     "symbol": "EMB",
     "decimals": 8,
-    "name": "Emblem",
-    "logo": "https://res.cloudinary.com/dnbcgedbu/image/upload/v1550314565/bc-logo-250x250.png"
+    "name": "Emblem"
   },
   {
     "address": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69",
     "symbol": "IOTX",
     "decimals": 18,
-    "name": "IoTeX Network"
+    "name": "IoTeX Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/iotx%402x.png"
   },
   {
     "address": "0xfec0cF7fE078a500abf15F1284958F22049c2C7e",
@@ -80,64 +79,58 @@
     "address": "0x3136eF851592aCf49CA4C825131E364170FA32b3",
     "symbol": "COFI",
     "decimals": 18,
-    "name": "CoinFi Token",
-    "logo": "https://blog.coinfi.com/wp-content/uploads/2018/01/coinfi-token-logo_28x28.png"
+    "name": "CoinFi Token"
   },
   {
     "address": "0xB563300A3BAc79FC09B93b6F84CE0d4465A2AC27",
     "symbol": "REDC",
     "decimals": 18,
-    "name": "RedCab",
-    "logo": "https://i.imgur.com/EgxuJmy.png"
+    "name": "RedCab"
   },
   {
     "address": "0xf85fEea2FdD81d51177F6b8F35F0e6734Ce45F5F",
     "symbol": "CMT",
     "decimals": 18,
     "name": "CyberMiles Token",
-    "logo": "http://res.5milesapp.com/image/upload/v1512116368/ico/cmt28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cmt%402x.png"
   },
   {
     "address": "0x3dC9a42fa7Afe57BE03c58fD7F4411b1E466C508",
     "symbol": "CLL",
     "decimals": 18,
-    "name": "CryptoLiveLeak",
-    "logo": "https://github.com/CryptoLiveLeak/CLL-Token/blob/master/28%20x%2028%20CLL%20png.png"
+    "name": "CryptoLiveLeak"
   },
   {
     "address": "0xfB48E0DEa837f9438309a7e9F0cFe7EE3353A84e",
     "symbol": "AFA",
     "decimals": 2,
-    "name": "Africahead Ipparts",
-    "logo": "https://www.africahead.co.za/Africahead/Africahead_logo/Africahead_logo_files/Africahead128X128tinypng.png"
+    "name": "Africahead Ipparts"
   },
   {
     "address": "0x85e076361cc813A908Ff672F9BAd1541474402b2",
     "symbol": "TEL (Telcoin)",
     "decimals": 2,
     "name": "Telcoin",
-    "logo": "https://www.telco.in/logo.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tel%402x.png"
   },
   {
     "address": "0xEc32A9725C59855d841ba7d8D9c99c84ff754688",
     "symbol": "TEL (Meditel)",
     "decimals": 18,
     "name": "Meditel",
-    "logo": "https://meditelcoin.com/wp-content/uploads/2018/11/logo-28px.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tel%402x.png"
   },
   {
     "address": "0xFFE02ee4C69eDf1b340fCaD64fbd6b37a7b9e265",
     "symbol": "NANJ",
     "decimals": 8,
-    "name": "NANJCOIN",
-    "logo": "https://etherscan.io/token/images/nanjcoin_28.png"
+    "name": "NANJCOIN"
   },
   {
     "address": "0xdf1338FbAfe7aF1789151627B886781ba556eF9a",
     "symbol": "KUE",
     "decimals": 18,
-    "name": "Kuende Token",
-    "logo": "https://cdn.kuende.com/images/new-klogo.png"
+    "name": "Kuende Token"
   },
   {
     "address": "0x23352036E911A22Cfc692B5E2E196692658ADED9",
@@ -155,8 +148,7 @@
     "address": "0xb5BB48567BfD0bFE9e4B08EF8b7f91556CC2a112",
     "symbol": "BCASH",
     "decimals": 18,
-    "name": "Bankcoin",
-    "logo": "https://bankcoinbcash.com/bcash.png"
+    "name": "Bankcoin"
   },
   {
     "address": "0x41dBECc1cdC5517C6f76f6a6E836aDbEe2754DE3",
@@ -168,8 +160,7 @@
     "address": "0xEB9951021698B42e4399f9cBb6267Aa35F82D59D",
     "symbol": "LIF",
     "decimals": 18,
-    "name": "Winding Tree",
-    "logo": "https://etherscan.io/token/images/lif_28.png"
+    "name": "Winding Tree"
   },
   {
     "address": "0x00c4B398500645eb5dA00a1a379a88B11683ba01",
@@ -211,13 +202,15 @@
     "address": "0xf230b790E05390FC8295F4d3F60332c93BEd42e2",
     "symbol": "TRX",
     "decimals": 6,
-    "name": "Tron Lab Token"
+    "name": "Tron Lab Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/trx%402x.png"
   },
   {
     "address": "0xfa05A73FfE78ef8f1a739473e462c54bae6567D9",
     "symbol": "LUN",
     "decimals": 18,
-    "name": "Lunyr"
+    "name": "Lunyr",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/lun%402x.png"
   },
   {
     "address": "0x4c382F8E09615AC86E08CE58266CC227e7d4D913",
@@ -235,8 +228,7 @@
     "address": "0xc0EA6306F6360FE7dCAB65D16Bf1a3AF92C79Aa2",
     "symbol": "GANA (1)",
     "decimals": 18,
-    "name": "GANA",
-    "logo": "http://cdn.ganacoin.io/logo/gana_symbol_24.png"
+    "name": "GANA"
   },
   {
     "address": "0x6754e21b9EAa053c62d7854dD6561ae451B0cBCf",
@@ -248,26 +240,28 @@
     "address": "0x5554e04e76533E1d14c52f05beEF6c9d329E1E30",
     "symbol": "NIO",
     "decimals": 0,
-    "name": "Autonio"
+    "name": "Autonio",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/nio%402x.png"
   },
   {
     "address": "0x7367A68039d4704f30BfBF6d948020C3B07DFC59",
     "symbol": "BCBC",
     "decimals": 18,
-    "name": "Beercoin"
+    "name": "Beercoin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bcbc%402x.png"
   },
   {
     "address": "0xa5F8fC0921880Cb7342368BD128eb8050442B1a1",
     "symbol": "ARY",
     "decimals": 18,
-    "name": "Block Array"
+    "name": "Block Array",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ary%402x.png"
   },
   {
     "address": "0xbf52F2ab39e26E0951d2a02b49B7702aBe30406a",
     "symbol": "ODE",
     "decimals": 18,
-    "name": "ODEM Token",
-    "logo": "https://odem.io/wp-content/uploads/2017/09/odem-logo-sq-v0.2.png"
+    "name": "ODEM Token"
   },
   {
     "address": "0x1460a58096d80a50a2F1f956DDA497611Fa4f165",
@@ -285,7 +279,8 @@
     "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
     "symbol": "AST",
     "decimals": 4,
-    "name": "Airswap"
+    "name": "Airswap",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ast%402x.png"
   },
   {
     "address": "0xf14922001A2FB8541a433905437ae954419C2439",
@@ -297,8 +292,7 @@
     "address": "0x16B0E62aC13a2fAeD36D18bce2356d25Ab3CfAD3",
     "symbol": "BTQ",
     "decimals": 18,
-    "name": "Bitcoin Boutique",
-    "logo": "https://s9.postimg.org/6r4j2hc3z/btcbtq.png"
+    "name": "Bitcoin Boutique"
   },
   {
     "address": "0x780116D91E5592E58a3b3c76A351571b39abCEc6",
@@ -310,14 +304,14 @@
     "address": "0x66497A283E0a007bA3974e837784C6AE323447de",
     "symbol": "PT",
     "decimals": 18,
-    "name": "PornToken",
-    "logo": "https://www.porntoken.io/porntoken.256.png"
+    "name": "PornToken"
   },
   {
     "address": "0xD0352a019e9AB9d757776F532377aAEbd36Fd541",
     "symbol": "FSN",
     "decimals": 18,
-    "name": "Fusion"
+    "name": "Fusion",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/fsn%402x.png"
   },
   {
     "address": "0xe81D72D14B1516e68ac3190a46C93302Cc8eD60f",
@@ -329,8 +323,7 @@
     "address": "0xc798cd1c49db0E297312E4c682752668CE1dB2AD",
     "symbol": "LFR",
     "decimals": 5,
-    "name": "LifeRun Coin",
-    "logo": "https://www.liferun.cc/static/LRF/images/liferun-logo28.png"
+    "name": "LifeRun Coin"
   },
   {
     "address": "0x986EE2B944c42D017F52Af21c4c69B84DBeA35d8",
@@ -342,8 +335,7 @@
     "address": "0xB31C219959E06f9aFBeB36b388a4BaD13E802725",
     "symbol": "ONOT",
     "decimals": 18,
-    "name": "ONO Token",
-    "logo": "https://github.com/MixinNetwork/asset-profile/blob/master/assets/1921926d-5cf7-3b2c-8458-860a4e241bfd/icon.png?raw=true"
+    "name": "ONO Token"
   },
   {
     "address": "0xb6EE9668771a79be7967ee29a63D4184F8097143",
@@ -355,28 +347,26 @@
     "address": "0xb5A5F22694352C15B00323844aD545ABb2B11028",
     "symbol": "ICX",
     "decimals": 18,
-    "name": "ICON"
+    "name": "ICON",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/icx%402x.png"
   },
   {
     "address": "0xa8006C4ca56F24d6836727D106349320dB7fEF82",
     "symbol": "INXT",
     "decimals": 8,
-    "name": "Internxt",
-    "logo": "https://internxt.com/img/logos/internxtcircle.png"
+    "name": "Internxt"
   },
   {
     "address": "0xc3bC9Eb71f75Ec439A6b6C8E8b746fCF5b62F703",
     "symbol": "VOC",
     "decimals": 18,
-    "name": "VORMACOIN",
-    "logo": "https://vormacoin.io/assets/images/logo/icon.png"
+    "name": "VORMACOIN"
   },
   {
     "address": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1",
     "symbol": "NCT",
     "decimals": 18,
-    "name": "Nectar",
-    "logo": "https://polyswarm.io/img/coin/nectar_300x300.png"
+    "name": "Nectar"
   },
   {
     "address": "0xE5F166c0D8872B68790061317BB6CcA04582C912",
@@ -388,7 +378,8 @@
     "address": "0x6F6DEb5db0C4994A8283A01D6CFeEB27Fc3bBe9C",
     "symbol": "SMART",
     "decimals": 0,
-    "name": "Smart Billions"
+    "name": "Smart Billions",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/smart%402x.png"
   },
   {
     "address": "0x27Dce1eC4d3f72C3E457Cc50354f1F975dDEf488",
@@ -400,15 +391,13 @@
     "address": "0xF4FE95603881D0e07954fD7605E0e9a916e42C44",
     "symbol": "WHEN",
     "decimals": 18,
-    "name": "WHEN Token",
-    "logo": "https://interface.whenhub.com/img/shares/when-token-icon.png"
+    "name": "WHEN Token"
   },
   {
     "address": "0xFcD862985628b254061F7A918035B80340D045d3",
     "symbol": "GIF",
     "decimals": 18,
-    "name": "GIFcoin Token",
-    "logo": "https://www.gifcoin.io/assets/images/default/frontend/gifsingle400.png"
+    "name": "GIFcoin Token"
   },
   {
     "address": "0x7B22938ca841aA392C93dBB7f4c42178E3d65E88",
@@ -450,7 +439,8 @@
     "address": "0xd4fa1460F537bb9085d22C7bcCB5DD450Ef28e3a",
     "symbol": "PPT",
     "decimals": 8,
-    "name": "Populous"
+    "name": "Populous",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ppt%402x.png"
   },
   {
     "address": "0x05C7065d644096a4E4C3FE24AF86e36dE021074b",
@@ -462,15 +452,13 @@
     "address": "0x4A37A91eec4C97F9090CE66d21D3B3Aadf1aE5aD",
     "symbol": "LCT (LiquorChain Token)",
     "decimals": 18,
-    "name": "LiquorChain Token",
-    "logo": "https://lct.blob.core.windows.net/lct/lct_logo_256.png"
+    "name": "LiquorChain Token"
   },
   {
     "address": "0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98",
     "symbol": "LIKE",
     "decimals": 18,
-    "name": "LikeCoin",
-    "logo": "https://like.co/logo.png"
+    "name": "LikeCoin"
   },
   {
     "address": "0xB9e7F8568e08d5659f5D29C4997173d84CdF2607",
@@ -482,8 +470,7 @@
     "address": "0x245ef47D4d0505ECF3Ac463F4d81f41ADE8f1fd1",
     "symbol": "NUG",
     "decimals": 18,
-    "name": "Nuggets Token",
-    "logo": "https://etherscan.io/token/images/nuggettoken_28.png"
+    "name": "Nuggets Token"
   },
   {
     "address": "0x30f4A3e0aB7a76733D8b60b89DD93c3D0b4c9E2f",
@@ -495,8 +482,7 @@
     "address": "0x83cee9e086A77e492eE0bB93C2B0437aD6fdECCc",
     "symbol": "MNTP",
     "decimals": 18,
-    "name": "Goldmint MNT Prelaunch Token",
-    "logo": "https://etherscan.io/token/images/goldmint_28.png"
+    "name": "Goldmint MNT Prelaunch Token"
   },
   {
     "address": "0xa1ccc166faf0E998b3E33225A1A0301B1C86119D",
@@ -526,7 +512,8 @@
     "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
     "symbol": "POLY",
     "decimals": 18,
-    "name": "Polymath Network"
+    "name": "Polymath Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/poly%402x.png"
   },
   {
     "address": "0x882448f83d90B2bf477Af2eA79327fDEA1335D93",
@@ -538,8 +525,7 @@
     "address": "0x5Dff89a2caa4D76bc286F74D67Bd718eb834da61",
     "symbol": "CFC",
     "decimals": 18,
-    "name": "CryptFillCoin",
-    "logo": "https://cryptfillcoin.com/images/resources/logo.png"
+    "name": "CryptFillCoin"
   },
   {
     "address": "0x1C62aCa2b7605Db3606eAcdA7Bc67A1857DDb8FF",
@@ -569,7 +555,8 @@
     "address": "0x177d39AC676ED1C67A2b268AD7F1E58826E5B0af",
     "symbol": "CDT",
     "decimals": 18,
-    "name": "CoinDash"
+    "name": "CoinDash",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cdt%402x.png"
   },
   {
     "address": "0x46492473755e8dF960F8034877F61732D718CE96",
@@ -581,14 +568,14 @@
     "address": "0x4D9e23a3842fE7Eb7682B9725cF6c507C424A41B",
     "symbol": "CAR (CarBlock)",
     "decimals": 18,
-    "name": "CarBlock",
-    "logo": "https://www.carblock.io/logo-400x400.png"
+    "name": "CarBlock"
   },
   {
     "address": "0x88A3E4F35D64aAD41A6d4030ac9AFE4356cB84fA",
     "symbol": "PRE",
     "decimals": 18,
-    "name": "Presearch"
+    "name": "Presearch",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/pre%402x.png"
   },
   {
     "address": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
@@ -613,7 +600,7 @@
     "symbol": "LOOM",
     "decimals": 18,
     "name": "Loom Network",
-    "logo": "https://s3.amazonaws.com/loomrandom/loom-ticker-logo+small.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/loom%402x.png"
   },
   {
     "address": "0xFACCD5Fc83c3E4C3c1AC1EF35D15adf06bCF209C",
@@ -625,29 +612,25 @@
     "address": "0x6F59e0461Ae5E2799F1fB3847f05a63B16d0DbF8",
     "symbol": "ORCA",
     "decimals": 18,
-    "name": "ORCA Token",
-    "logo": "https://drive.google.com/open?id=1lCrBZQ7CNkVcUwPPet4j4WU7p1TUrY_1"
+    "name": "ORCA Token"
   },
   {
     "address": "0xBA3a79D758f19eFe588247388754b8e4d6EddA81",
     "symbol": "VSF",
     "decimals": 18,
-    "name": "VeriSafe",
-    "logo": "https://www.verisafe.io/logo-128.png"
+    "name": "VeriSafe"
   },
   {
     "address": "0x86E56f3c89a14528858e58B3De48c074538BAf2c",
     "symbol": "RING (1)",
     "decimals": 18,
-    "name": "Evolution Land Global Token",
-    "logo": "https://imgland.oss-cn-hangzhou.aliyuncs.com/photo/2018/450e60bc-bad7-4058-822d-b88ed4e82262.png"
+    "name": "Evolution Land Global Token"
   },
   {
     "address": "0x9469D013805bFfB7D3DEBe5E7839237e535ec483",
     "symbol": "RING (2)",
     "decimals": 18,
-    "name": "Evolution Land Global Token",
-    "logo": "https://imgland.oss-cn-hangzhou.aliyuncs.com/photo/2018/450e60bc-bad7-4058-822d-b88ed4e82262.png"
+    "name": "Evolution Land Global Token"
   },
   {
     "address": "0x40395044Ac3c0C57051906dA938B54BD6557F212",
@@ -671,28 +654,26 @@
     "address": "0x3883f5e181fccaF8410FA61e12b59BAd963fb645",
     "symbol": "THETA",
     "decimals": 18,
-    "name": "Theta Token"
+    "name": "Theta Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/theta%402x.png"
   },
   {
     "address": "0xCDB7eCFd3403Eef3882c65B761ef9B5054890a47",
     "symbol": "$HUR",
     "decimals": 18,
-    "name": "$Hurify Token",
-    "logo": "https://hurify.co/wp-content/uploads/2018/03/hurify_fav_icon.png"
+    "name": "$Hurify Token"
   },
   {
     "address": "0xd8446236FA95b9b5f9fd0f8E7Df1a944823c683d",
     "symbol": "NEEO",
     "decimals": 18,
-    "name": "NEEO",
-    "logo": "https://raw.githubusercontent.com/maksimov1/eth-contract-metadata/master/images/neeo.png"
+    "name": "NEEO"
   },
   {
     "address": "0xbF18F246B9301F231e9561B35A3879769BB46375",
     "symbol": "CARE",
     "decimals": 18,
-    "name": "Token CARE",
-    "logo": "https://tombcare.com/images/logo.png"
+    "name": "Token CARE"
   },
   {
     "address": "0x17e67d1CB4e349B9CA4Bc3e17C7DF2a397A7BB64",
@@ -740,8 +721,7 @@
     "address": "0x5c39bC68e58a242A624E4FC96be77A383C52002D",
     "symbol": "BKB (BitKeep Token)",
     "decimals": 18,
-    "name": "BitKeep Token",
-    "logo": "https://bitkeep.com/img/bitkeep_28.png"
+    "name": "BitKeep Token"
   },
   {
     "address": "0xB2Bfeb70B903F1BAaC7f2ba2c62934C7e5B974C4",
@@ -765,8 +745,7 @@
     "address": "0x574B36BceD443338875d171CC377E691f7d4F887",
     "symbol": "CO2Bit",
     "decimals": 18,
-    "name": "CO2Bit",
-    "logo": "http://co2bit.com/wp-content/uploads/2017/12/28x28.png"
+    "name": "CO2Bit"
   },
   {
     "address": "0x5c743a35E903F6c584514ec617ACEe0611Cf44f3",
@@ -784,8 +763,7 @@
     "address": "0x5B8D43FfdE4a2982B9A5387cDF21D54Ead64Ac8d",
     "symbol": "MEST",
     "decimals": 18,
-    "name": "Monaco Estate",
-    "logo": "https://image.ibb.co/eYVsoH/monaco_estate_logo_28x28.png"
+    "name": "Monaco Estate"
   },
   {
     "address": "0x81b4D08645DA11374a03749AB170836E4e539767",
@@ -803,39 +781,41 @@
     "address": "0xbbFF862d906E348E9946Bfb2132ecB157Da3D4b4",
     "symbol": "SS (1)",
     "decimals": 18,
-    "name": "Sharder",
-    "logo": "https://oss.sharder.org/sharder/Token/Token-logo-132x132.png"
+    "name": "Sharder"
   },
   {
     "address": "0xB15fE5a123e647ba594CEa7A1E648646f95EB4AA",
     "symbol": "SS (2)",
     "decimals": 18,
-    "name": "Sharder",
-    "logo": "https://oss.sharder.org/sharder/Token/Token-logo-132x132.png"
+    "name": "Sharder"
   },
   {
     "address": "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6",
     "symbol": "REP (1)",
     "decimals": 18,
-    "name": "Augur"
+    "name": "Augur",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rep%402x.png"
   },
   {
     "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
     "symbol": "REP (2)",
     "decimals": 18,
-    "name": "Augur"
+    "name": "Augur",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rep%402x.png"
   },
   {
     "address": "0x9B11EFcAAA1890f6eE52C6bB7CF8153aC5d74139",
     "symbol": "ATM",
     "decimals": 8,
-    "name": "ATMChain"
+    "name": "ATMChain",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/atm%402x.png"
   },
   {
     "address": "0x818Fc6C2Ec5986bc6E2CBf00939d90556aB12ce5",
     "symbol": "KIN",
     "decimals": 18,
-    "name": "Kin Foundation"
+    "name": "Kin Foundation",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/kin%402x.png"
   },
   {
     "address": "0x22F0AF8D78851b72EE799e05F54A77001586B18A",
@@ -865,15 +845,13 @@
     "address": "0x905E337c6c8645263D3521205Aa37bf4d034e745",
     "symbol": "MTC (Medical Token Currency)",
     "decimals": 18,
-    "name": "Medical Token Currency",
-    "logo": "https://cdn.docademic.com/images/ico/mtc200.png"
+    "name": "Medical Token Currency"
   },
   {
     "address": "0xdfdc0D82d96F8fd40ca0CFB4A288955bECEc2088",
     "symbol": "MTC (MTC Mesh Network)",
     "decimals": 18,
-    "name": "MTC Mesh Network",
-    "logo": "http://bbs.mtc.io/upload/picture/user/avatar/7218.jpg"
+    "name": "MTC Mesh Network"
   },
   {
     "address": "0x43F6a1BE992deE408721748490772B15143CE0a7",
@@ -885,56 +863,51 @@
     "address": "0x519475b31653E46D20cD09F9FdcF3B12BDAcB4f5",
     "symbol": "VIU",
     "decimals": 18,
-    "name": "Viuly",
-    "logo": "https://etherscan.io/token/images/viuly_28.png"
+    "name": "Viuly"
   },
   {
     "address": "0x3c75226555FC496168d48B88DF83B95F16771F37",
     "symbol": "DROP",
     "decimals": 0,
-    "name": "Droplex"
+    "name": "Droplex",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/drop%402x.png"
   },
   {
     "address": "0x8c39afDf7B17F12c553208555E51ab86E69C35aA",
     "symbol": "FR8",
     "decimals": 8,
-    "name": "Fr8 Network",
-    "logo": "https://i.imgur.com/9woJDw5.png"
+    "name": "Fr8 Network"
   },
   {
     "address": "0x57Ab1E02fEE23774580C119740129eAC7081e9D3",
     "symbol": "sUSD",
     "decimals": 18,
-    "name": "USD Synth (sUSD)",
-    "logo": "https://www.synthetix.io/img/sUSD_blue_sml.png"
+    "name": "USD Synth (sUSD)"
   },
   {
     "address": "0xcc7d26D8eA6281BB363C8448515F2C61F7BC19F0",
     "symbol": "ABCH",
     "decimals": 18,
-    "name": "ABBC Cash",
-    "logo": "https://github.com/ABBCCash/ABBCCashtoken/blob/master/images/ABCH_128px.png"
+    "name": "ABBC Cash"
   },
   {
     "address": "0xe8780B48bdb05F928697A5e8155f672ED91462F7",
     "symbol": "CAS (Cashaa)",
     "decimals": 18,
-    "name": "Cashaa",
-    "logo": "https://cashaa.com/img/tkn-icon1.png"
+    "name": "Cashaa"
   },
   {
     "address": "0x779492d3644dDF4495Aa2d80C468E1B7be6AF1d2",
     "symbol": "CAS (CAS Coin)",
     "decimals": 2,
-    "name": "CAS Coin",
-    "logo": "http://cas.casino/assets/img/logo/mew.png"
+    "name": "CAS Coin"
   },
   {
     "address": "0x2C4e8f2D746113d0696cE89B35F0d8bF88E0AEcA",
     "symbol": "OST",
     "decimals": 18,
     "name": "Simple Token 'OST'",
-    "logo": "https://etherscan.io/token/images/ost_28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ost%402x.png"
   },
   {
     "address": "0xE2492F8D2A2618d8709Ca99b1d8d75713Bd84089",
@@ -946,8 +919,7 @@
     "address": "0xb67734521eAbBE9C773729dB73E16CC2dfb20A58",
     "symbol": "E₹",
     "decimals": 2,
-    "name": "eRupee",
-    "logo": "https://raw.githubusercontent.com/eRupee/images/master/coin%20logo.png"
+    "name": "eRupee"
   },
   {
     "address": "0xB802b24E0637c2B87D2E8b7784C055BBE921011a",
@@ -1001,7 +973,8 @@
     "address": "0xc27A2F05fa577a83BA0fDb4c38443c0718356501",
     "symbol": "TAU",
     "decimals": 18,
-    "name": "Lamden Tau"
+    "name": "Lamden Tau",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tau%402x.png"
   },
   {
     "address": "0x2cb101d7dA0ebaA57D3F2fEf46D7FFB7BB64592B",
@@ -1019,22 +992,19 @@
     "address": "0x737F98AC8cA59f2C68aD658E3C3d8C8963E40a4c",
     "symbol": "AMN",
     "decimals": 18,
-    "name": "Amon",
-    "logo": "https://amon.tech/assets/img/token/amn.png"
+    "name": "Amon"
   },
   {
     "address": "0x3f06B5D78406cD97bdf10f5C420B241D32759c80",
     "symbol": "CYFM",
     "decimals": 18,
-    "name": "CyberFM",
-    "logo": "https://mftu.net/tokeninfo/cyfm/0x3f06B5D78406cD97bdf10f5C420B241D32759c80.png"
+    "name": "CyberFM"
   },
   {
     "address": "0xE40C374d8805b1dD58CDcEFf998A2F6920Cb52FD",
     "symbol": "PRPS (1)",
     "decimals": 18,
-    "name": "Purpose",
-    "logo": "https://imgur.com/hm9naIz"
+    "name": "Purpose"
   },
   {
     "address": "0x7641b2Ca9DDD58adDf6e3381c1F994Aac5f1A32f",
@@ -1046,8 +1016,7 @@
     "address": "0xd94F2778e2B3913C53637Ae60647598bE588c570",
     "symbol": "PRPS (3)",
     "decimals": 18,
-    "name": "Purpose",
-    "logo": "https://imgur.com/hm9naIz"
+    "name": "Purpose"
   },
   {
     "address": "0x1f41E42D0a9e3c0Dd3BA15B527342783B43200A9",
@@ -1065,21 +1034,20 @@
     "address": "0x4470BB87d77b963A013DB939BE332f927f2b992e",
     "symbol": "ADX",
     "decimals": 4,
-    "name": "AdEx Network"
+    "name": "AdEx Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/adx%402x.png"
   },
   {
     "address": "0x1543d0F83489e82A1344DF6827B23d541F235A50",
     "symbol": "ATH (AIgatha Token)",
     "decimals": 18,
-    "name": "AIgatha Token",
-    "logo": "https://aigatha.com/img/AIgatha_Logo.png"
+    "name": "AIgatha Token"
   },
   {
     "address": "0x68d53441c0e253f76c500e551bdeA3D102206C9a",
     "symbol": "DST",
     "decimals": 18,
-    "name": "Dimensions Strike Token",
-    "logo": "https://dimensions.network/static/home/img/branding/logo_o_400px.png"
+    "name": "Dimensions Strike Token"
   },
   {
     "address": "0xfd8971d5E8E1740cE2d0A84095fCA4De729d0c16",
@@ -1091,8 +1059,7 @@
     "address": "0x05D412CE18F24040bB3Fa45CF2C69e506586D8e8",
     "symbol": "MFTU",
     "decimals": 18,
-    "name": "Mainstream For The Underground",
-    "logo": "https://mftu.net/tokeninfo/mftu/0x05D412CE18F24040bB3Fa45CF2C69e506586D8e8.png"
+    "name": "Mainstream For The Underground"
   },
   {
     "address": "0xc7BbA5b765581eFb2Cdd2679DB5Bea9eE79b201f",
@@ -1116,41 +1083,39 @@
     "address": "0xf3C092cA8CD6D3d4ca004Dc1d0f1fe8CcAB53599",
     "symbol": "ZIX",
     "decimals": 18,
-    "name": "ZIX",
-    "logo": "https://res.cloudinary.com/zeexme/image/upload/v1525772378/logo_svg.svg"
+    "name": "ZIX"
   },
   {
     "address": "0x697beac28B09E122C4332D163985e8a73121b97F",
     "symbol": "QRL",
     "decimals": 8,
-    "name": "QRL"
+    "name": "QRL",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/qrl%402x.png"
   },
   {
     "address": "0x77761e63C05aeE6648FDaeaa9B94248351AF9bCd",
     "symbol": "PASS (PASS Token)",
     "decimals": 18,
-    "name": "PASS Token",
-    "logo": "http://www.wisepass.co/wordpress/home/images/logo.png"
+    "name": "PASS Token"
   },
   {
     "address": "0xeE4458e052B533b1aABD493B5f8c4d85D7B263Dc",
     "symbol": "PASS (Blockpass)",
     "decimals": 6,
-    "name": "Blockpass",
-    "logo": "https://cdn.blockpass.org/images/pass-token.png"
+    "name": "Blockpass"
   },
   {
     "address": "0x7064aAb39A0Fcf7221c3396719D0917a65E35515",
     "symbol": "CPLO",
     "decimals": 18,
-    "name": "CPOLLO",
-    "logo": "https://cpollo.info/wp-content/uploads/ct-logos/logo_ff07eb8edb884a94d3d89c118e8dc2c6_1x.png"
+    "name": "CPOLLO"
   },
   {
     "address": "0xb3104b4B9Da82025E8b9F8Fb28b3553ce2f67069",
     "symbol": "BIX",
     "decimals": 18,
-    "name": "Bibox Token"
+    "name": "Bibox Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bix%402x.png"
   },
   {
     "address": "0xEbeD4fF9fe34413db8fC8294556BBD1528a4DAca",
@@ -1162,8 +1127,7 @@
     "address": "0xB4272071eCAdd69d933AdcD19cA99fe80664fc08",
     "symbol": "XCHF",
     "decimals": 18,
-    "name": "CryptoFranc",
-    "logo": "https://swisscryptotokens.ch/wp-content/uploads/2018/11/XCHF_Logo_CMC.png"
+    "name": "CryptoFranc"
   },
   {
     "address": "0x0B4BdC478791897274652DC15eF5C135cae61E60",
@@ -1182,14 +1146,13 @@
     "symbol": "ONG",
     "decimals": 18,
     "name": "SoMee.Social",
-    "logo": "https://etherscan.io/token/images/ongcoin_28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ong%402x.png"
   },
   {
     "address": "0xEd7fEA78C393cF7B17B152A8c2D0CD97aC31790B",
     "symbol": "DUBI (DUBI)",
     "decimals": 18,
-    "name": "DUBI",
-    "logo": "https://imgur.com/qoz7jTX"
+    "name": "DUBI"
   },
   {
     "address": "0xD4CffeeF10F60eCA581b5E1146B5Aca4194a4C3b",
@@ -1201,14 +1164,14 @@
     "address": "0x9c6Fa42209169bCeA032e401188a6fc3e9C9f59c",
     "symbol": "DUBI (3)",
     "decimals": 18,
-    "name": "Decentralized Universal Basic Income",
-    "logo": "https://imgur.com/qoz7jTX"
+    "name": "Decentralized Universal Basic Income"
   },
   {
     "address": "0x9a642d6b3368ddc662CA244bAdf32cDA716005BC",
     "symbol": "QTUM",
     "decimals": 18,
-    "name": "Qtum"
+    "name": "Qtum",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/qtum%402x.png"
   },
   {
     "address": "0xA017ac5faC5941f95010b12570B812C974469c2C",
@@ -1226,8 +1189,7 @@
     "address": "0x1966d718A565566e8E202792658D7b5Ff4ECe469",
     "symbol": "NDX",
     "decimals": 18,
-    "name": "nDEX",
-    "logo": "https://raw.githubusercontent.com/ndexnetwork/NDX/master/nDEX.png"
+    "name": "nDEX"
   },
   {
     "address": "0x44449Fa4d607F807d1eD4a69ad942971728391C8",
@@ -1239,41 +1201,39 @@
     "address": "0x9a49f02e128a8E989b443a8f94843C0918BF45E7",
     "symbol": "TOK",
     "decimals": 8,
-    "name": "TOKOK",
-    "logo": "https://www.tokok.com/hryfile/f/f/624147c121ea402ea96bf7c66e0b825b.png"
+    "name": "TOKOK"
   },
   {
     "address": "0xE814aeE960a85208C3dB542C53E7D4a6C8D5f60F",
     "symbol": "DAY",
     "decimals": 18,
-    "name": "ChronoLogic DAY",
-    "logo": "https://chronologic.network/img/chronologic_tokenlogo128.png"
+    "name": "ChronoLogic DAY"
   },
   {
     "address": "0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4",
     "symbol": "ENG",
     "decimals": 8,
-    "name": "Enigma"
+    "name": "Enigma",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/eng%402x.png"
   },
   {
     "address": "0xE6DfBF1FAcA95036B8E76e1Fb28933D025B76Cc0",
     "symbol": "LIBER",
     "decimals": 18,
-    "name": "Libereum",
-    "logo": "https://www.libereum.io/images/iconmew.png"
+    "name": "Libereum"
   },
   {
     "address": "0x725B190Bc077FFde17Cf549AA8ba25e298550B18",
     "symbol": "CORI",
     "decimals": 2,
-    "name": "Corrently Invest Token",
-    "logo": "https://corrently.de/token/img/logo_square.png"
+    "name": "Corrently Invest Token"
   },
   {
     "address": "0xEa1f346faF023F974Eb5adaf088BbCdf02d761F4",
     "symbol": "TIX",
     "decimals": 18,
-    "name": "Blocktix"
+    "name": "Blocktix",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tix%402x.png"
   },
   {
     "address": "0x4F4f0Db4de903B88f2B1a2847971E231D54F8fd3",
@@ -1309,8 +1269,7 @@
     "address": "0x89cbeAC5E8A13F0Ebb4C74fAdFC69bE81A501106",
     "symbol": "DEPO (Depository Network)",
     "decimals": 18,
-    "name": "DEPO (Depository Network)",
-    "logo": "https://i.imgur.com/ar18ECx.png"
+    "name": "DEPO (Depository Network)"
   },
   {
     "address": "0x324A48eBCbB46e61993931eF9D35F6697CD2901b",
@@ -1340,8 +1299,7 @@
     "address": "0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244",
     "symbol": "RVT",
     "decimals": 18,
-    "name": "Rivetz",
-    "logo": "https://rivetz.com/img/logo/color-250px.png"
+    "name": "Rivetz"
   },
   {
     "address": "0x12480E24eb5bec1a9D4369CaB6a80caD3c0A377A",
@@ -1377,7 +1335,8 @@
     "address": "0xFA1a856Cfa3409CFa145Fa4e20Eb270dF3EB21ab",
     "symbol": "IOST",
     "decimals": 18,
-    "name": "IOSToken"
+    "name": "IOSToken",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/iost%402x.png"
   },
   {
     "address": "0x3A1237D38D0Fb94513f85D61679cAd7F38507242",
@@ -1413,13 +1372,15 @@
     "address": "0xBA5F11b16B155792Cf3B2E6880E8706859A8AEB6",
     "symbol": "ARN",
     "decimals": 8,
-    "name": "Aeron"
+    "name": "Aeron",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/arn%402x.png"
   },
   {
     "address": "0x42d6622deCe394b54999Fbd73D108123806f6a18",
     "symbol": "SPANK",
     "decimals": 18,
-    "name": "SpankChain"
+    "name": "SpankChain",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/spank%402x.png"
   },
   {
     "address": "0x9972A0F24194447E73a7e8b6CD26a52e02DDfAD5",
@@ -1431,35 +1392,32 @@
     "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
     "symbol": "SNT",
     "decimals": 18,
-    "name": "Status Network Token"
+    "name": "Status Network Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/snt%402x.png"
   },
   {
     "address": "0x9E7D29bd499B6c7da2a5B2EaFCF4A39d3BD845D1",
     "symbol": "CTGC",
     "decimals": 18,
-    "name": "Convenient To Go",
-    "logo": "https://www.ctgcoin.org/upload/logo/ctg.logo.png"
+    "name": "Convenient To Go"
   },
   {
     "address": "0xe9C9e7E1DaBea830C958C39D6b25964a6F52143A",
     "symbol": "HEY",
     "decimals": 18,
-    "name": "HeyToken",
-    "logo": "https://assets.hey.network/public/icon/icon-512x512%401x.png"
+    "name": "HeyToken"
   },
   {
     "address": "0xc520F3Ac303a107D8F4B08b326B6ea66A4f961cd",
     "symbol": "LG",
     "decimals": 18,
-    "name": "LG",
-    "logo": "https://res.cloudinary.com/lnky/image/upload/v1541827304/lg/lg.jpg"
+    "name": "LG"
   },
   {
     "address": "0xF813F3902bBc00A6DCe378634d3B79D84F9803d7",
     "symbol": "PATH",
     "decimals": 18,
-    "name": "PATH",
-    "logo": "https://path.network/images/path-128x128.png"
+    "name": "PATH"
   },
   {
     "address": "0x430241368c1D293fdA21DBa8Bb7aF32007c59109",
@@ -1477,7 +1435,8 @@
     "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
     "symbol": "CVC",
     "decimals": 8,
-    "name": "Civic"
+    "name": "Civic",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cvc%402x.png"
   },
   {
     "address": "0xe25bCec5D3801cE3a794079BF94adF1B8cCD802D",
@@ -1501,15 +1460,13 @@
     "address": "0xe9dE1C630753A15d7021Cc563429c21d4887506F",
     "symbol": "OPEN (OPEN)",
     "decimals": 8,
-    "name": "OPEN",
-    "logo": "https://www.openfuture.io/assets/fancyLogo/Open_Fancy-Logo_120x120.png"
+    "name": "OPEN"
   },
   {
     "address": "0x69c4BB240cF05D51eeab6985Bab35527d04a8C64",
     "symbol": "OPEN (OPEN Platform)",
     "decimals": 8,
-    "name": "OPEN Platform",
-    "logo": "https://www.openfuture.io/assets/fancyLogo/Open_Fancy-Logo_120x120.png"
+    "name": "OPEN Platform"
   },
   {
     "address": "0x588047365dF5BA589F923604AAC23d673555c623",
@@ -1521,8 +1478,7 @@
     "address": "0xBb0eF9e617FADdf54B8D16e29046F72B4D3ec77F",
     "symbol": "PEP",
     "decimals": 18,
-    "name": "PEP Token",
-    "logo": "https://ipfs.io/ipfs/QmXFjbvkcwfhCHFnYS6L41MMk4Grh14qjDSyXHy5vutc4Y"
+    "name": "PEP Token"
   },
   {
     "address": "0xf028ADEe51533b1B47BEaa890fEb54a457f51E89",
@@ -1552,15 +1508,13 @@
     "address": "0xA686514FAF7d54289266F483D1e4852C99E13EC7",
     "symbol": "WORK (Aworker)",
     "decimals": 8,
-    "name": "Aworker",
-    "logo": "https://aworker.io/img/home/about/aworker28.png"
+    "name": "Aworker"
   },
   {
     "address": "0xD18e454D844eb0009D32E07A0Cde89E18d64CFb4",
     "symbol": "WORK (workTOKEN)",
     "decimals": 18,
-    "name": "workTOKEN",
-    "logo": "https://workchain.io/downloads/workTOKEN/logo_256.png"
+    "name": "workTOKEN"
   },
   {
     "address": "0x23Ccc43365D9dD3882eab88F43d515208f832430",
@@ -1638,8 +1592,7 @@
     "address": "0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8",
     "symbol": "ELY",
     "decimals": 18,
-    "name": "ELYCOIN",
-    "logo": "https://elycoin.io/assets/images/ely128.png"
+    "name": "ELYCOIN"
   },
   {
     "address": "0x5acD19b9c91e596b1f062f18e3D02da7eD8D1e50",
@@ -1657,8 +1610,7 @@
     "address": "0xE43E2041dc3786e166961eD9484a5539033d10fB",
     "symbol": "DNX",
     "decimals": 18,
-    "name": "DenCity",
-    "logo": "https://dencity.life/assets/images/logo.png"
+    "name": "DenCity"
   },
   {
     "address": "0x1c79ab32C66aCAa1e9E81952B8AAa581B43e54E7",
@@ -1676,8 +1628,7 @@
     "address": "0xdfC3e857c8cCEA7657E0ed98AB92e048e38deE0f",
     "symbol": "FIH",
     "decimals": 18,
-    "name": "FidelityHouse Token",
-    "logo": "https://www.fidelityhouse.io/assets/logo_fidelityhouse-28x28.png"
+    "name": "FidelityHouse Token"
   },
   {
     "address": "0x8542325B72C6D9fC0aD2Ca965A78435413a915A0",
@@ -1695,8 +1646,7 @@
     "address": "0xE5aeE163513119F4F750376C718766B40fA37A5F",
     "symbol": "Fzcoin",
     "decimals": 18,
-    "name": "Frozencoin Network",
-    "logo": "https://avatars2.githubusercontent.com/u/44194025?s=400&u=970b2065cf404120fe0f9e486c506003aa96563f&v=4"
+    "name": "Frozencoin Network"
   },
   {
     "address": "0xAA19961b6B858D9F18a115f25aa1D98ABc1fdBA8",
@@ -1720,28 +1670,26 @@
     "address": "0x3A92bD396aEf82af98EbC0Aa9030D25a23B11C6b",
     "symbol": "TBX",
     "decimals": 18,
-    "name": "Tokenbox"
+    "name": "Tokenbox",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tbx%402x.png"
   },
   {
     "address": "0xBb1f24C0c1554b9990222f036b0AaD6Ee4CAec29",
     "symbol": "SOUL",
     "decimals": 18,
-    "name": "CryptoSoul",
-    "logo": "https://ibb.co/fHXJ1o"
+    "name": "CryptoSoul"
   },
   {
     "address": "0x84543F868eC1b1FAC510d49d13C069f64cD2d5f9",
     "symbol": "Hdp.ф",
     "decimals": 18,
-    "name": "HEdpAY",
-    "logo": "http://hedpay.com/content/images/systemCustom/o5VT92nyPRvA7E5j7ij265rHsezBdwnk04bXYqoY0OTsUF4IzFEIubdyfRlkLcDH_28x28.png?version=4.7.1&width=809&height=509"
+    "name": "HEdpAY"
   },
   {
     "address": "0x70b147E01E9285E7cE68B9BA437Fe3a9190E756a",
     "symbol": "FLX",
     "decimals": 18,
-    "name": "BitFlux",
-    "logo": "https://fluxproject.xyz/gallery_gen/271ecfb9c8f4f7dfc5ea539cfa57f44d_150x150.png"
+    "name": "BitFlux"
   },
   {
     "address": "0xEF2E9966eb61BB494E5375d5Df8d67B7dB8A780D",
@@ -1753,7 +1701,8 @@
     "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
     "symbol": "OMG",
     "decimals": 18,
-    "name": "OmiseGO"
+    "name": "OmiseGO",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/omg%402x.png"
   },
   {
     "address": "0x499A6B77bc25C26bCf8265E2102B1B3dd1617024",
@@ -1765,8 +1714,7 @@
     "address": "0xcbf15FB8246F679F9Df0135881CB29a3746f734b",
     "symbol": "BTR (Bither Platform Token)",
     "decimals": 18,
-    "name": "Bither Platform Token",
-    "logo": "https://bitherplatform.io/images/logo/BTR.png"
+    "name": "Bither Platform Token"
   },
   {
     "address": "0x6DD4e4Aad29A40eDd6A409b9c1625186C9855b4D",
@@ -1790,15 +1738,13 @@
     "address": "0xfA0eF5E034CaE1AE752d59bdb8aDcDe37Ed7aB97",
     "symbol": "TCA",
     "decimals": 18,
-    "name": "TangguoTao Token",
-    "logo": "https://www.tcandy.io/images/logo.png"
+    "name": "TangguoTao Token"
   },
   {
     "address": "0x37427576324fE1f3625c9102674772d7CF71377d",
     "symbol": "SGT (SelfieYo Gold Token)",
     "decimals": 18,
-    "name": "SelfieYo Gold Token",
-    "logo": "https://sgt.selfieyo.com/wp-content/uploads/2018/01/token-new.png"
+    "name": "SelfieYo Gold Token"
   },
   {
     "address": "0xd248B0D48E44aaF9c49aea0312be7E13a6dc1468",
@@ -1822,7 +1768,8 @@
     "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
     "symbol": "REQ",
     "decimals": 18,
-    "name": "Request Network"
+    "name": "Request Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/req%402x.png"
   },
   {
     "address": "0xA13f0743951B4f6E3e3AA039f682E17279f52bc3",
@@ -1840,8 +1787,7 @@
     "address": "0x0947b0e6D821378805c9598291385CE7c791A6B2",
     "symbol": "LND",
     "decimals": 18,
-    "name": "Lendingblock",
-    "logo": "https://etherscan.io/token/images/lendingblock_28.png"
+    "name": "Lendingblock"
   },
   {
     "address": "0x72D32ac1c5E66BfC5b08806271f8eEF915545164",
@@ -1853,8 +1799,7 @@
     "address": "0x62CD07D414Ec50B68C7EcAa863a23d344f2d062f",
     "symbol": "WIC",
     "decimals": 0,
-    "name": "WickNote",
-    "logo": "http://wicknote.com/wicklogo-small.png"
+    "name": "WickNote"
   },
   {
     "address": "0x41875C2332B0877cDFAA699B641402b7D4642c32",
@@ -1872,15 +1817,13 @@
     "address": "0x65A15014964F2102Ff58647e16a16a6B9E14bCF6",
     "symbol": "Ox Fina",
     "decimals": 3,
-    "name": "Ox Fina",
-    "logo": "https://etherscan.io/token/images/oxfina_28.png"
+    "name": "Ox Fina"
   },
   {
     "address": "0xb3616550aBc8AF79c7A5902DEF9Efa3bC9A95200",
     "symbol": "TLX",
     "decimals": 8,
-    "name": "Telex",
-    "logo": "http://telexai.com/img/tlxlogo.png"
+    "name": "Telex"
   },
   {
     "address": "0xd73A66B8FB26Be8B0AcD7c52Bd325054Ac7d468b",
@@ -1916,8 +1859,7 @@
     "address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
     "symbol": "HOT (Holo)",
     "decimals": 18,
-    "name": "Holo Token",
-    "logo": "https://holo.host/wp-content/uploads/2017/12/Holologo_Profile.png"
+    "name": "Holo Token"
   },
   {
     "address": "0x28b5E12CcE51f15594B0b91d5b5AdaA70F684a02",
@@ -1953,7 +1895,8 @@
     "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
     "symbol": "ENJ",
     "decimals": 18,
-    "name": "ENJIN"
+    "name": "ENJIN",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/enj%402x.png"
   },
   {
     "address": "0x24DCc881E7Dd730546834452F21872D5cb4b5293",
@@ -1971,15 +1914,13 @@
     "address": "0x423e4322CDDa29156b49a17dfbd2aCC4b280600D",
     "symbol": "CAR",
     "decimals": 9,
-    "name": "Car Sharing Community",
-    "logo": "https://mycarcoin.com/Carcoin/img/logo-carcoin.png"
+    "name": "Car Sharing Community"
   },
   {
     "address": "0x7728dFEF5aBd468669EB7f9b48A7f70a501eD29D",
     "symbol": "PRG",
     "decimals": 6,
-    "name": "Paragon",
-    "logo": "https://etherscan.io/token/images/paragon2.png"
+    "name": "Paragon"
   },
   {
     "address": "0x35a69642857083BA2F30bfaB735dacC7F0bac969",
@@ -2009,8 +1950,7 @@
     "address": "0xCd4b4b0F3284a33AC49C67961EC6e111708318Cf",
     "symbol": "AX1",
     "decimals": 5,
-    "name": "AX1 Mining Token",
-    "logo": "https://ax1.io/images/AX1-Platinum-Coin.png"
+    "name": "AX1 Mining Token"
   },
   {
     "address": "0x78c292D1445E6b9558bf42e8BC369271DeD062eA",
@@ -2040,14 +1980,14 @@
     "address": "0x3EDD235C3E840C1F29286B2e39370a255C7B6fdb",
     "symbol": "CMBT",
     "decimals": 8,
-    "name": "CMBToken",
-    "logo": "https://2.bp.blogspot.com/-J35HB-_P0u8/WngvMTjjb6I/AAAAAAAAKzI/KO0DgrLZAV0TxF8dc3faw36XqR9msmP2gCLcBGAs/s1600/eth-cmbt.png"
+    "name": "CMBToken"
   },
   {
     "address": "0xf7B098298f7C69Fc14610bf71d5e02c60792894C",
     "symbol": "GUP",
     "decimals": 3,
-    "name": "Matchpool"
+    "name": "Matchpool",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gup%402x.png"
   },
   {
     "address": "0xB70835D7822eBB9426B56543E391846C107bd32C",
@@ -2083,7 +2023,8 @@
     "address": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
     "symbol": "DAI",
     "decimals": 18,
-    "name": "Dai Stablecoin v1.0"
+    "name": "Dai Stablecoin v1.0",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dai%402x.png"
   },
   {
     "address": "0x1183F92A5624D68e85FFB9170F16BF0443B4c242",
@@ -2095,14 +2036,14 @@
     "address": "0xC2494604e9DcEfa2A70dCEbf81e6D7BE064a334e",
     "symbol": "OWT",
     "decimals": 18,
-    "name": "OpenWeb Token",
-    "logo": "https://openweb.network/images/logo-s.png"
+    "name": "OpenWeb Token"
   },
   {
     "address": "0xd2d6158683aeE4Cc838067727209a0aAF4359de3",
     "symbol": "BNTY",
     "decimals": 18,
-    "name": "Bounty0x Token"
+    "name": "Bounty0x Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bnty%402x.png"
   },
   {
     "address": "0x10B123FdDde003243199aaD03522065dC05827A0",
@@ -2126,7 +2067,8 @@
     "address": "0x86Fa049857E0209aa7D9e616F7eb3b3B78ECfdb0",
     "symbol": "EOS",
     "decimals": 18,
-    "name": "EOS"
+    "name": "EOS",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/eos%402x.png"
   },
   {
     "address": "0x6863bE0e7CF7ce860A574760e9020D519a8bDC47",
@@ -2144,14 +2086,14 @@
     "address": "0x93a7174dafd31d13400cD9fa01f4e5B5BAa00D39",
     "symbol": "HAK",
     "decimals": 18,
-    "name": "Shaka",
-    "logo": "https://www.friendsfingers.com/img/brand-resources/shaka_logo_white.png"
+    "name": "Shaka"
   },
   {
     "address": "0x2d0E95bd4795D7aCe0da3C0Ff7b706a5970eb9D3",
     "symbol": "SOC",
     "decimals": 18,
-    "name": "All Sports"
+    "name": "All Sports",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/soc%402x.png"
   },
   {
     "address": "0x3a26746Ddb79B1B8e4450e3F4FFE3285A307387E",
@@ -2175,15 +2117,13 @@
     "address": "0xa5dB1d6F7A0D5Bccc17d0bFD39D7AF32d5E5EDc6",
     "symbol": "TICO (1)",
     "decimals": 5,
-    "name": "Topinvestmentcoin",
-    "logo": "https://i.imgur.com/DnDglhQ.png"
+    "name": "Topinvestmentcoin"
   },
   {
     "address": "0x7F4B2A690605A7cbb66F7AA6885EbD906a5e2E9E",
     "symbol": "TICO (2)",
     "decimals": 8,
-    "name": "Topinvestmentcoin",
-    "logo": "https://i.imgur.com/lrPtg1X.png"
+    "name": "Topinvestmentcoin"
   },
   {
     "address": "0xAf30D2a7E90d7DC361c8C4585e9BB7D2F6f15bc7",
@@ -2207,21 +2147,20 @@
     "address": "0x66186008C1050627F979d464eABb258860563dbE",
     "symbol": "MDS",
     "decimals": 18,
-    "name": "MediShares"
+    "name": "MediShares",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mds%402x.png"
   },
   {
     "address": "0x1C3BB10dE15C31D5DBE48fbB7B87735d1B7d8c32",
     "symbol": "BLO",
     "decimals": 18,
-    "name": "BLONDCOIN",
-    "logo": "http://www.blondcoin.com/images/blondcoin-logo-128.png"
+    "name": "BLONDCOIN"
   },
   {
     "address": "0x2134057C0b461F898D375Cead652Acae62b59541",
     "symbol": "CXC",
     "decimals": 18,
-    "name": "CoxxxCoin",
-    "logo": "http://www.coxxxcoin.com/CoxxxCoin.256.png"
+    "name": "CoxxxCoin"
   },
   {
     "address": "0x16662F73dF3e79e54c6c5938b4313f92C524C120",
@@ -2245,15 +2184,14 @@
     "address": "0x2467AA6B5A2351416fD4C3DeF8462d841feeecEC",
     "symbol": "QBX",
     "decimals": 18,
-    "name": "qiibeeToken",
-    "logo": "https://avatars0.githubusercontent.com/u/31820267?s=400&u=f671cf8b24876d0dddf9b16930d31cc2114103eb&v=4"
+    "name": "qiibeeToken"
   },
   {
     "address": "0x5E6b6d9aBAd9093fdc861Ea1600eBa1b355Cd940",
     "symbol": "ITC",
     "decimals": 18,
     "name": "IoT Chain",
-    "logo": "http://etherscan.io/token/images/iotchain28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/itc%402x.png"
   },
   {
     "address": "0xD9A12Cde03a86E800496469858De8581D3A5353d",
@@ -2277,7 +2215,8 @@
     "address": "0xD0a4b8946Cb52f0661273bfbC6fD0E0C75Fc6433",
     "symbol": "STORM",
     "decimals": 18,
-    "name": "Storm Token"
+    "name": "Storm Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/storm%402x.png"
   },
   {
     "address": "0x74C1E4b8caE59269ec1D85D3D4F324396048F4ac",
@@ -2307,15 +2246,13 @@
     "address": "0xf75fBfa2f681860B9A6D19FC3FF3D34CB322E2D6",
     "symbol": "CIYA",
     "decimals": 18,
-    "name": "CRYPTORIYA",
-    "logo": "https://etherscan.io/token/images/cryptoriya_28.png"
+    "name": "CRYPTORIYA"
   },
   {
     "address": "0x315cE59FAFd3A8d562b7Ec1C8542382d2710b06c",
     "symbol": "CCS",
     "decimals": 18,
-    "name": "CacaoShares",
-    "logo": "http://cacaoshares.com/wp-content/uploads/2017/12/cropped-logo-cherry-2018-1-e1513046302595.png"
+    "name": "CacaoShares"
   },
   {
     "address": "0x80BC5512561c7f85A3A9508c7df7901b370Fa1DF",
@@ -2333,22 +2270,19 @@
     "address": "0x9B62513c8a27290CF6A7A9e29386e600245EA819",
     "symbol": "CPT (Contents Protocol Token)",
     "decimals": 18,
-    "name": "Contents Protocol Token",
-    "logo": "https://contentsprotocol.io/icon_128x128.png"
+    "name": "Contents Protocol Token"
   },
   {
     "address": "0x66eb65D7Ab8e9567ba0fa6E37c305956c5341574",
     "symbol": "HLX",
     "decimals": 5,
-    "name": "Helex",
-    "logo": "https://helex.world/logoescan.png"
+    "name": "Helex"
   },
   {
     "address": "0xf6cFe53d6FEbaEEA051f400ff5fc14F0cBBDacA1",
     "symbol": "DGPT",
     "decimals": 18,
-    "name": "DigiPulse",
-    "logo": "https://files.coinmarketcap.com/static/img/coins/200x200/digipulse.png"
+    "name": "DigiPulse"
   },
   {
     "address": "0x13119E34E140097a507B07a5564bDe1bC375D9e6",
@@ -2372,22 +2306,19 @@
     "address": "0x65Be44C747988fBF606207698c944Df4442efE19",
     "symbol": "FUCK (Finally Usable Crypto Karma)",
     "decimals": 4,
-    "name": "Finally Usable Crypto Karma",
-    "logo": "https://etherscan.io/token/images/fucktoken_28.png"
+    "name": "Finally Usable Crypto Karma"
   },
   {
     "address": "0xAb16E0d25c06CB376259cc18C1de4ACA57605589",
     "symbol": "FUCK (FinallyUsableCryptoKarma)",
     "decimals": 4,
-    "name": "FinallyUsableCryptoKarma",
-    "logo": "https://etherscan.io/token/images/fucktoken_28.png"
+    "name": "FinallyUsableCryptoKarma"
   },
   {
     "address": "0xA52383B665b91DCe42dD4b6d1E0Fb37d3EFFe489",
     "symbol": "MUSD",
     "decimals": 18,
-    "name": "MASTER USD",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1553022473/MUSD-Logo-128x128.png"
+    "name": "MASTER USD"
   },
   {
     "address": "0x899338b84D25aC505a332aDCE7402d697D947494",
@@ -2423,8 +2354,7 @@
     "address": "0x9AF839687F6C94542ac5ece2e317dAAE355493A1",
     "symbol": "HOT (Hydro)",
     "decimals": 18,
-    "name": "Hydro Protocol",
-    "logo": "https://s2.coinmarketcap.com/static/img/coins/32x32/2430.png"
+    "name": "Hydro Protocol"
   },
   {
     "address": "0x7FCE2856899a6806eeEf70807985fc7554C66340",
@@ -2448,15 +2378,13 @@
     "address": "0xe933c0Cd9784414d5F278C114904F5A84b396919",
     "symbol": "WHO (1)",
     "decimals": 18,
-    "name": "WhoHas",
-    "logo": "https://whohas.io/wp-content/uploads/2018/02/blueEye_blackText.png"
+    "name": "WhoHas"
   },
   {
     "address": "0xe200641890772FCe8eE6EDc5354cCEa30ac92F49",
     "symbol": "WHO (2)",
     "decimals": 18,
-    "name": "WhoHas",
-    "logo": "https://whohas.io/wp-content/uploads/2018/02/blueEye_blackText.png"
+    "name": "WhoHas"
   },
   {
     "address": "0xf6b6AA0Ef0f5Edc2C1c5d925477F97eAF66303e7",
@@ -2480,7 +2408,8 @@
     "address": "0xCeD4E93198734dDaFf8492d525Bd258D49eb388E",
     "symbol": "EDO",
     "decimals": 18,
-    "name": "Eidoo"
+    "name": "Eidoo",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/edo%402x.png"
   },
   {
     "address": "0x0Ebb614204E47c09B6C3FeB9AAeCad8EE060E23E",
@@ -2516,8 +2445,7 @@
     "address": "0x922aC473A3cC241fD3a0049Ed14536452D58D73c",
     "symbol": "VLD",
     "decimals": 18,
-    "name": "VETRI",
-    "logo": "https://vetri.global/static/img/vld-icon.png"
+    "name": "VETRI"
   },
   {
     "address": "0xc20464e0C373486d2B3335576e83a218b1618A5E",
@@ -2529,15 +2457,13 @@
     "address": "0x4946Fcea7C692606e8908002e55A582af44AC121",
     "symbol": "FOAM",
     "decimals": 18,
-    "name": "FOAM Token",
-    "logo": "https://ipfs.io/ipfs/QmQLg44xb349BLV2qVAuRzRoGZXdm8JN26bWY5yRbzcpZ5"
+    "name": "FOAM Token"
   },
   {
     "address": "0x6aEDbF8dFF31437220dF351950Ba2a3362168d1b",
     "symbol": "DGS",
     "decimals": 8,
-    "name": "Dragonglass",
-    "logo": "https://dragonglass.com/wp-content/uploads/2018/06/LogoX132_color_2.png"
+    "name": "Dragonglass"
   },
   {
     "address": "0xdA6cb58A0D0C01610a29c5A65c303e13e885887C",
@@ -2567,8 +2493,7 @@
     "address": "0x78B7FADA55A64dD895D8c8c35779DD8b67fA8a05",
     "symbol": "ATL",
     "decimals": 18,
-    "name": "ATLANT",
-    "logo": "https://atlant.io/promo/Atlant_custom_300x300_logo.png"
+    "name": "ATLANT"
   },
   {
     "address": "0x8eFFd494eB698cc399AF6231fCcd39E08fd20B15",
@@ -2580,8 +2505,7 @@
     "address": "0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF",
     "symbol": "DGX",
     "decimals": 9,
-    "name": "Digix Gold Token",
-    "logo": "https://raw.githubusercontent.com/DigixGlobal/digix-press-kit/master/dgx-token.png"
+    "name": "Digix Gold Token"
   },
   {
     "address": "0xC34B21f6F8e51cC965c2393B3ccFa3b82BEb2403",
@@ -2593,8 +2517,7 @@
     "address": "0x9847345de8b614c956146bbea549336d9C8d26b6",
     "symbol": "GULD",
     "decimals": 8,
-    "name": "GULD ERC20",
-    "logo": "https://guld.io/img/logo.png"
+    "name": "GULD ERC20"
   },
   {
     "address": "0x8Ae4BF2C33a8e667de34B54938B0ccD03Eb8CC06",
@@ -2606,8 +2529,7 @@
     "address": "0xd0929d411954c47438dc1d871dd6081F5C5e149c",
     "symbol": "RFR",
     "decimals": 4,
-    "name": "Refereum",
-    "logo": "https://etherscan.io/token/images/refereum.png"
+    "name": "Refereum"
   },
   {
     "address": "0xfe5F141Bf94fE84bC28deD0AB966c16B17490657",
@@ -2631,14 +2553,14 @@
     "address": "0x4E84E9e5fb0A972628Cf4568c403167EF1D40431",
     "symbol": "$FFC",
     "decimals": 18,
-    "name": "$Fluzcoin",
-    "logo": "https://i.imgur.com/ar18ECx.png"
+    "name": "$Fluzcoin"
   },
   {
     "address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
     "symbol": "DATA",
     "decimals": 18,
-    "name": "Streamr DATAcoin"
+    "name": "Streamr DATAcoin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/data%402x.png"
   },
   {
     "address": "0x68e14bb5A45B9681327E16E528084B9d962C1a39",
@@ -2650,8 +2572,7 @@
     "address": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
     "symbol": "PNK",
     "decimals": 18,
-    "name": "Pinakion",
-    "logo": "https://kleros.io/favicon-32x32.png"
+    "name": "Pinakion"
   },
   {
     "address": "0xEDD7c94FD7B4971b916d15067Bc454b9E1bAD980",
@@ -2663,7 +2584,8 @@
     "address": "0x4DC3643DbC642b72C158E7F3d2ff232df61cb6CE",
     "symbol": "AMB",
     "decimals": 18,
-    "name": "Amber Token"
+    "name": "Amber Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/amb%402x.png"
   },
   {
     "address": "0x17F93475d2A978f527c3f7c44aBf44AdfBa60D5C",
@@ -2681,21 +2603,20 @@
     "address": "0x809826cceAb68c387726af962713b64Cb5Cb3CCA",
     "symbol": "NCASH",
     "decimals": 18,
-    "name": "Nucleus Vision"
+    "name": "Nucleus Vision",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ncash%402x.png"
   },
   {
     "address": "0xC011A72400E58ecD99Ee497CF89E3775d4bd732F",
     "symbol": "SNX",
     "decimals": 18,
-    "name": "Synthetix Network Token",
-    "logo": "https://www.synthetix.io/favicons/favicon.ico"
+    "name": "Synthetix Network Token"
   },
   {
     "address": "0xB4b1D2C217EC0776584CE08D3DD98F90EDedA44b",
     "symbol": "CO2",
     "decimals": 18,
-    "name": "Climatecoin",
-    "logo": "https://climatecoin.io/uploads/logosmall-1-42x42.png"
+    "name": "Climatecoin"
   },
   {
     "address": "0x52fb36C83ad33C1824912FC81071cA5eEB8AB390",
@@ -2713,14 +2634,14 @@
     "address": "0x0843971B4ac6e842a518AA184e0271d88B5cB74F",
     "symbol": "XCL",
     "decimals": 8,
-    "name": "CLASSIE",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1551593804/classie-xcl-logo-28x28.png"
+    "name": "CLASSIE"
   },
   {
     "address": "0x07e3c70653548B04f0A75970C1F81B4CBbFB606f",
     "symbol": "DLT",
     "decimals": 18,
-    "name": "Agrello"
+    "name": "Agrello",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dlt%402x.png"
   },
   {
     "address": "0x9a005c9a89BD72a4Bd27721E7a09A3c11D2b03C4",
@@ -2732,27 +2653,27 @@
     "address": "0x8a77e40936BbC27e80E9a3F526368C967869c86D",
     "symbol": "MVP",
     "decimals": 18,
-    "name": "Merculet",
-    "logo": "https://merculet.io/static/image/newimg/logo.png"
+    "name": "Merculet"
   },
   {
     "address": "0x2C974B2d0BA1716E644c1FC59982a89DDD2fF724",
     "symbol": "VIB",
     "decimals": 18,
-    "name": "Viberate"
+    "name": "Viberate",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/vib%402x.png"
   },
   {
     "address": "0xc42209aCcC14029c1012fB5680D95fBd6036E2a0",
     "symbol": "PPP",
     "decimals": 18,
-    "name": "PayPie"
+    "name": "PayPie",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ppp%402x.png"
   },
   {
     "address": "0xF722B01910F93B84EDa9CA128b9F05821A41EAe1",
     "symbol": "VRE",
     "decimals": 18,
-    "name": "Vrenelium",
-    "logo": "https://www.vrenelium.com/wp-content/uploads/2019/03/vrenelium-xs.png"
+    "name": "Vrenelium"
   },
   {
     "address": "0x1BcBc54166F6bA149934870b60506199b6C9dB6D",
@@ -2764,8 +2685,7 @@
     "address": "0xF67451Dc8421F0e0afEB52faa8101034ed081Ed9",
     "symbol": "GAM",
     "decimals": 8,
-    "name": "Gambit",
-    "logo": "https://gateway.ipfs.io/ipfs/QmSDhPfF52qV7KcYMQ6kosvxc9TnMY45fMHst2hJEscUoh"
+    "name": "Gambit"
   },
   {
     "address": "0x5a84969bb663fb64F6d015DcF9F622Aedc796750",
@@ -2777,7 +2697,8 @@
     "address": "0xEa11755Ae41D889CeEc39A63E6FF75a02Bc1C00d",
     "symbol": "CTXC",
     "decimals": 18,
-    "name": "Cortex"
+    "name": "Cortex",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ctxc%402x.png"
   },
   {
     "address": "0x190e569bE071F40c704e15825F285481CB74B6cC",
@@ -2789,21 +2710,21 @@
     "address": "0x6f259637dcD74C767781E37Bc6133cd6A68aa161",
     "symbol": "HT",
     "decimals": 18,
-    "name": "Huobi Token"
+    "name": "Huobi Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ht%402x.png"
   },
   {
     "address": "0x075c60EE2cD308ff47873b38Bd9A0Fa5853382c4",
     "symbol": "DEEZ",
     "decimals": 18,
     "name": "DeezNuts",
-    "logo": "https://raw.githubusercontent.com/DeezNutsToken/DEEZ/master/images/DeezNuts.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/deez%402x.png"
   },
   {
     "address": "0xe530441f4f73bDB6DC2fA5aF7c3fC5fD551Ec838",
     "symbol": "GSE",
     "decimals": 4,
-    "name": "GSENetwork",
-    "logo": "https://www.gse.network/static/media/gse-logo.png"
+    "name": "GSENetwork"
   },
   {
     "address": "0x05aAaA829Afa407D83315cDED1d45EB16025910c",
@@ -2815,15 +2736,13 @@
     "address": "0xD3C00772B24D997A812249ca637a921e81357701",
     "symbol": "WILD",
     "decimals": 18,
-    "name": "WILD Token",
-    "logo": "http://wildtoken.com/wp-content/uploads/2017/12/WildCrypto-Logo-Only-copy-300x275.png"
+    "name": "WILD Token"
   },
   {
     "address": "0x04cC783b450b8D11F3C7d00DD03fDF7FB51fE9F2",
     "symbol": "FLMC (1)",
     "decimals": 18,
-    "name": "Filmscoin",
-    "logo": "https://filmscoin.com/images/icon-flmc28.png"
+    "name": "Filmscoin"
   },
   {
     "address": "0x5976F7dac1525eF3277836043bA474a35E6B4272",
@@ -2859,8 +2778,7 @@
     "address": "0xa838be6E4b760E6061D4732D6B9F11Bf578f9A76",
     "symbol": "TTV",
     "decimals": 18,
-    "name": "TV-TWO: Token for Television",
-    "logo": "https://tv-two.com/ttv.png"
+    "name": "TV-TWO: Token for Television"
   },
   {
     "address": "0x9041Fe5B3FDEA0f5e4afDC17e75180738D877A01",
@@ -2896,8 +2814,7 @@
     "address": "0x0E3de3B0E3D617FD8D1D8088639bA877feb4d742",
     "symbol": "ROCK2PAY",
     "decimals": 18,
-    "name": "ICE ROCK MINING",
-    "logo": "https://rockmining.blob.core.windows.net/logo/fullLogo.png"
+    "name": "ICE ROCK MINING"
   },
   {
     "address": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45",
@@ -2933,15 +2850,13 @@
     "address": "0x5B0751713b2527d7f002c0c4e2a37e1219610A6B",
     "symbol": "HORSE",
     "decimals": 18,
-    "name": "Ethorse",
-    "logo": "https://ethorse.com/images/ethorse-logo.png"
+    "name": "Ethorse"
   },
   {
     "address": "0xb787d4eAc8899730bb8C57fc3c998c49c5244ec0",
     "symbol": "CPEX",
     "decimals": 8,
-    "name": "CoinPulseToken",
-    "logo": "https://i.imgur.com/GaPxtv5.png"
+    "name": "CoinPulseToken"
   },
   {
     "address": "0xC2C63F23ec5E97efbD7565dF9Ec764FDc7d4e91d",
@@ -2959,8 +2874,7 @@
     "address": "0x8293bBd92C42608B20af588620a76128A33e4De9",
     "symbol": "CATS",
     "decimals": 6,
-    "name": "CATCOIN",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1553016325/catcoin-logo-128x128.png"
+    "name": "CATCOIN"
   },
   {
     "address": "0x26DB5439F651CAF491A87d48799dA81F191bDB6b",
@@ -2984,7 +2898,8 @@
     "address": "0xe8Ff5C9c75dEb346acAc493C463C8950Be03Dfba",
     "symbol": "VIBE",
     "decimals": 18,
-    "name": "VIBE Coin"
+    "name": "VIBE Coin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/vibe%402x.png"
   },
   {
     "address": "0xCA29db4221c111888a7e80b12eAc8a266Da3Ee0d",
@@ -3008,8 +2923,7 @@
     "address": "0xe1A178B681BD05964d3e3Ed33AE731577d9d96dD",
     "symbol": "BOX (BOX Token)",
     "decimals": 18,
-    "name": "BOX Token",
-    "logo": "https://box.la/box_logo200px.png"
+    "name": "BOX Token"
   },
   {
     "address": "0x63f584FA56E60e4D0fE8802b27C7e6E3b33E007f",
@@ -3021,8 +2935,7 @@
     "address": "0x90162f41886c0946D09999736f1C15c8a105A421",
     "symbol": "FAN",
     "decimals": 18,
-    "name": "Fan Token",
-    "logo": "https://imgland.oss-cn-hangzhou.aliyuncs.com/photo/2018/c80e9fbb-c8f9-4c66-9044-0c4c32392405.png"
+    "name": "Fan Token"
   },
   {
     "address": "0x8a88f04e0c905054D2F33b26BB3A46D7091A039A",
@@ -3034,13 +2947,15 @@
     "address": "0x672a1AD4f667FB18A333Af13667aa0Af1F5b5bDD",
     "symbol": "CRED",
     "decimals": 18,
-    "name": "Verify"
+    "name": "Verify",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cred%402x.png"
   },
   {
     "address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
     "symbol": "TKN",
     "decimals": 8,
-    "name": "TokenCard"
+    "name": "TokenCard",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tkn%402x.png"
   },
   {
     "address": "0x336F646F87D9f6bC6Ed42Dd46E8b3fD9DbD15C22",
@@ -3058,14 +2973,14 @@
     "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "symbol": "USDC",
     "decimals": 6,
-    "name": "USD//Coin"
+    "name": "USD//Coin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/usdc%402x.png"
   },
   {
     "address": "0xE9fF07809CCff05daE74990e25831d0Bc5cbe575",
     "symbol": "Hdp",
     "decimals": 18,
-    "name": "HEdpAY",
-    "logo": "http://hedpay.com/content/images/systemCustom/o5VT92nyPRvA7E5j7ij265rHsezBdwnk04bXYqoY0OTsUF4IzFEIubdyfRlkLcDH_28x28.png?version=4.7.1&width=809&height=509"
+    "name": "HEdpAY"
   },
   {
     "address": "0xFc2C4D8f95002C14eD0a7aA65102Cac9e5953b5E",
@@ -3083,15 +2998,13 @@
     "address": "0x7e9e431a0B8c4D532C745B1043c7FA29a48D4fBa",
     "symbol": "eosDAC",
     "decimals": 18,
-    "name": "eosDAC",
-    "logo": "https://eosdac.io/wp-content/uploads/2018/03/eosdaclogo1-200-jpeg.jpg"
+    "name": "eosDAC"
   },
   {
     "address": "0x0cF713b11C9b986EC40D65bD4F7fbd50F6ff2d64",
     "symbol": "IST34",
     "decimals": 18,
-    "name": "IST34 Token",
-    "logo": "https://hiperteknoloji.org/ht/ist34-token-28.png"
+    "name": "IST34 Token"
   },
   {
     "address": "0x0F33bb20a282A7649C7B3AFf644F084a9348e933",
@@ -3103,7 +3016,8 @@
     "address": "0xb45d7Bc4cEBcAB98aD09BABDF8C818B2292B672c",
     "symbol": "HODL",
     "decimals": 18,
-    "name": "HODLCoin"
+    "name": "HODLCoin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/hodl%402x.png"
   },
   {
     "address": "0xF26ef5E0545384b7Dcc0f297F2674189586830DF",
@@ -3121,21 +3035,20 @@
     "address": "0x009e864923b49263c7F10D19B7f8Ab7a9A5AAd33",
     "symbol": "FKX",
     "decimals": 18,
-    "name": "Knoxstertoken",
-    "logo": "https://fortknoxster.com/wp-content/uploads/2017/11/FortKnoxster-Icon-256.png"
+    "name": "Knoxstertoken"
   },
   {
     "address": "0x80A7E048F37A50500351C204Cb407766fA3baE7f",
     "symbol": "CRPT",
     "decimals": 18,
-    "name": "CrypteriumToken"
+    "name": "CrypteriumToken",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/crpt%402x.png"
   },
   {
     "address": "0x4a57E687b9126435a9B19E4A802113e266AdeBde",
     "symbol": "FXC (Flexacoin)",
     "decimals": 18,
-    "name": "Flexacoin",
-    "logo": "https://flexacoin.org/logo.png"
+    "name": "Flexacoin"
   },
   {
     "address": "0xc92D6E3E64302C59d734f3292E2A13A13D7E1817",
@@ -3147,20 +3060,22 @@
     "address": "0x168296bb09e24A88805CB9c33356536B980D3fC5",
     "symbol": "RHOC",
     "decimals": 8,
-    "name": "RChain"
+    "name": "RChain",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rhoc%402x.png"
   },
   {
     "address": "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
     "symbol": "BNB",
     "decimals": 18,
     "name": "Binance Coin",
-    "logo": "https://etherscan.io/token/images/binance_28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bnb%402x.png"
   },
   {
     "address": "0x70a72833d6bF7F508C8224CE59ea1Ef3d0Ea3A38",
     "symbol": "UTK",
     "decimals": 18,
-    "name": "UTRUST"
+    "name": "UTRUST",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/utk%402x.png"
   },
   {
     "address": "0x44197A4c44D6A059297cAf6be4F7e172BD56Caaf",
@@ -3190,8 +3105,7 @@
     "address": "0x767bA2915EC344015a7938E3eEDfeC2785195D05",
     "symbol": "REA",
     "decimals": 18,
-    "name": "Realisto",
-    "logo": "https://realisto.io/files/images/rea-token-logo-128x136.png"
+    "name": "Realisto"
   },
   {
     "address": "0x6781a0F84c7E9e846DCb84A9a5bd49333067b104",
@@ -3233,13 +3147,15 @@
     "address": "0xd4c435F5B09F855C3317c8524Cb1F586E42795fa",
     "symbol": "CND",
     "decimals": 18,
-    "name": "Cindicator"
+    "name": "Cindicator",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cnd%402x.png"
   },
   {
     "address": "0xa5Fd1A791C4dfcaacC963D4F73c6Ae5824149eA7",
     "symbol": "JNT",
     "decimals": 18,
-    "name": "Jibrel Network"
+    "name": "Jibrel Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/jnt%402x.png"
   },
   {
     "address": "0x9af2c6B1A28D3d6BC084bd267F70e90d49741D5B",
@@ -3281,7 +3197,8 @@
     "address": "0x888666CA69E0f178DED6D75b5726Cee99A87D698",
     "symbol": "ICN",
     "decimals": 18,
-    "name": "ICONOMI"
+    "name": "ICONOMI",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/icn%402x.png"
   },
   {
     "address": "0xfF5c25D2F40B47C4a37f989DE933E26562Ef0Ac0",
@@ -3299,15 +3216,13 @@
     "address": "0xEBBdf302c940c6bfd49C6b165f457fdb324649bc",
     "symbol": "HYDRO",
     "decimals": 18,
-    "name": "Hydro",
-    "logo": "https://i.imgur.com/15s0da4.png"
+    "name": "Hydro"
   },
   {
     "address": "0xfeDAE5642668f8636A11987Ff386bfd215F942EE",
     "symbol": "PAL",
     "decimals": 18,
-    "name": "PolicyPal Network",
-    "logo": "https://etherscan.io/token/images/policypal_28.png"
+    "name": "PolicyPal Network"
   },
   {
     "address": "0x163733bcc28dbf26B41a8CfA83e369b5B3af741b",
@@ -3337,27 +3252,27 @@
     "address": "0x8d80de8A78198396329dfA769aD54d24bF90E7aa",
     "symbol": "NAC",
     "decimals": 18,
-    "name": "Nami ICO",
-    "logo": "https://drive.google.com/file/d/1D8Oh0j1l_Q7MFbqyGmNFHNE2pw-lyXmw/view"
+    "name": "Nami ICO"
   },
   {
     "address": "0x056017c55aE7AE32d12AeF7C679dF83A85ca75Ff",
     "symbol": "WYV",
     "decimals": 18,
-    "name": "WyvernToken",
-    "logo": "https://raw.githubusercontent.com/ProjectWyvern/wyvern-branding/master/logo/logo-square-red-transparent-28x28.png"
+    "name": "WyvernToken"
   },
   {
     "address": "0x618E75Ac90b12c6049Ba3b27f5d5F8651b0037F6",
     "symbol": "QASH",
     "decimals": 6,
-    "name": "QASH"
+    "name": "QASH",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/qash%402x.png"
   },
   {
     "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
     "symbol": "BAT",
     "decimals": 18,
-    "name": "Basic Attention Token"
+    "name": "Basic Attention Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bat%402x.png"
   },
   {
     "address": "0x6531f133e6DeeBe7F2dcE5A0441aA7ef330B4e53",
@@ -3375,14 +3290,15 @@
     "address": "0x05f4a42e251f2d52b8ed15E9FEdAacFcEF1FAD27",
     "symbol": "ZIL",
     "decimals": 12,
-    "name": "Zilliqa"
+    "name": "Zilliqa",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/zil%402x.png"
   },
   {
     "address": "0x80fB784B7eD66730e8b1DBd9820aFD29931aab03",
     "symbol": "LEND",
     "decimals": 18,
     "name": "EHTLend",
-    "logo": "https://raw.githubusercontent.com/ETHLend/logos/master/LEND_128x128.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/lend%402x.png"
   },
   {
     "address": "0xE3F4b4A5d91e5cB9435B947F090A319737036312",
@@ -3394,15 +3310,13 @@
     "address": "0xfcAC7A7515e9A9d7619fA77A1fa738111f66727e",
     "symbol": "PCH (PITCH)",
     "decimals": 18,
-    "name": "PITCH",
-    "logo": "https://image.ibb.co/e9kStm/Pitch_Apply_Token_logo_500x500.png"
+    "name": "PITCH"
   },
   {
     "address": "0xA40106134c5bF4c41411554e6db99B95A15ed9d8",
     "symbol": "ROCK",
     "decimals": 18,
-    "name": "Rocket Token",
-    "logo": "https://rocketico.io/app/media/token_icon.png"
+    "name": "Rocket Token"
   },
   {
     "address": "0xcC4eF9EEAF656aC1a2Ab886743E98e97E090ed38",
@@ -3414,7 +3328,8 @@
     "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
     "symbol": "GNO",
     "decimals": 18,
-    "name": "Gnosis"
+    "name": "Gnosis",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gno%402x.png"
   },
   {
     "address": "0xdD41fBd1Ae95C5D9B198174A28e04Be6b3d1aa27",
@@ -3426,8 +3341,7 @@
     "address": "0x4D807509aECe24C0fa5A102b6a3B059Ec6E14392",
     "symbol": "ONE",
     "decimals": 18,
-    "name": "Menlo One",
-    "logo": "https://github.com/MenloOne/menlo-one-logos/blob/master/128x128%20Menlo%20One%20Logo.png?raw=true"
+    "name": "Menlo One"
   },
   {
     "address": "0x9541FD8B9b5FA97381783783CeBF2F5fA793C262",
@@ -3439,27 +3353,27 @@
     "address": "0xf3Db5Fa2C66B7aF3Eb0C0b782510816cbe4813b8",
     "symbol": "EVX",
     "decimals": 4,
-    "name": "EVX Token"
+    "name": "EVX Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/evx%402x.png"
   },
   {
     "address": "0x47dD62D4D075DeAd71d0e00299fc56a2d747beBb",
     "symbol": "EQL",
     "decimals": 18,
-    "name": "Equal"
+    "name": "Equal",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/eql%402x.png"
   },
   {
     "address": "0xc96DF921009B790dfFcA412375251ed1A2b75c60",
     "symbol": "ORME (1)",
     "decimals": 8,
-    "name": "Ormeus Coin",
-    "logo": "https://s2.coinmarketcap.com/static/img/coins/32x32/1998.png"
+    "name": "Ormeus Coin"
   },
   {
     "address": "0x516E5436bAfdc11083654DE7Bb9b95382d08d5DE",
     "symbol": "ORME (2)",
     "decimals": 8,
-    "name": "Ormeus Coin",
-    "logo": "https://s2.coinmarketcap.com/static/img/coins/32x32/1998.png"
+    "name": "Ormeus Coin"
   },
   {
     "address": "0xe06eda7435bA749b047380CEd49121ddE93334Ae",
@@ -3495,15 +3409,13 @@
     "address": "0xecd570bBf74761b960Fa04Cc10fe2c4e86FfDA36",
     "symbol": "STP",
     "decimals": 8,
-    "name": "StashPay",
-    "logo": "https://etherscan.io/token/images/stash_28.png"
+    "name": "StashPay"
   },
   {
     "address": "0x9a9bB9b4b11BF8eccff84B58a6CCCCD4058A7f0D",
     "symbol": "VD",
     "decimals": 8,
-    "name": "Bitcoin Card",
-    "logo": "https://bitcoincard.me/vd.png"
+    "name": "Bitcoin Card"
   },
   {
     "address": "0x76974C7B79dC8a6a109Fd71fd7cEb9E40eff5382",
@@ -3527,8 +3439,7 @@
     "address": "0xFA456Cf55250A839088b27EE32A424d7DAcB54Ff",
     "symbol": "BTTX",
     "decimals": 18,
-    "name": "Blocktrade.com",
-    "logo": "https://blocktrade.com/wp-content/uploads/2018/05/blocktradecom_logo.png?39a15b&39a15b"
+    "name": "Blocktrade.com"
   },
   {
     "address": "0xcfb98637bcae43C13323EAa1731cED2B716962fD",
@@ -3553,13 +3464,14 @@
     "symbol": "DTH",
     "decimals": 18,
     "name": "dether",
-    "logo": "https://ipfs.io/ipfs/QmTbnd1okDoU188cLCFvZorxWgfVHdoLwwnLKxkJJFcncv"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dth%402x.png"
   },
   {
     "address": "0xe3818504c1B32bF1557b16C238B2E01Fd3149C17",
     "symbol": "PLR",
     "decimals": 18,
-    "name": "Pillar Project"
+    "name": "Pillar Project",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/plr%402x.png"
   },
   {
     "address": "0xfFe8196bc259E8dEDc544d935786Aa4709eC3E64",
@@ -3571,14 +3483,14 @@
     "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
     "symbol": "ABT",
     "decimals": 18,
-    "name": "ArcBlock Token"
+    "name": "ArcBlock Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/abt%402x.png"
   },
   {
     "address": "0x386Faa4703a34a7Fdb19Bec2e14Fd427C9638416",
     "symbol": "DCA",
     "decimals": 18,
-    "name": "DoBetAcceptBet",
-    "logo": "https://cdn1.savepice.ru/uploads/2018/2/13/8c1a008b4e617ec75c4febe81f32ced5-full.png"
+    "name": "DoBetAcceptBet"
   },
   {
     "address": "0x7A5fF295Dc8239d5C2374E4D894202aAF029Cab6",
@@ -3590,8 +3502,7 @@
     "address": "0xC0Eb85285d83217CD7c891702bcbC0FC401E2D9D",
     "symbol": "HVN",
     "decimals": 8,
-    "name": "Hiveterminal Token",
-    "logo": "https://hive-project.net/images/hive-logo.png"
+    "name": "Hiveterminal Token"
   },
   {
     "address": "0x4993CB95c7443bdC06155c5f5688Be9D8f6999a5",
@@ -3615,8 +3526,7 @@
     "address": "0xf44745fBd41F6A1ba151df190db0564c5fCc4410",
     "symbol": "CPY",
     "decimals": 18,
-    "name": "COPYTRACK",
-    "logo": "https://cdn.copytrack.io/media/cpy.png?auto=compress&w=200"
+    "name": "COPYTRACK"
   },
   {
     "address": "0xa6a840E50bCaa50dA017b91A0D86B8b2d41156EE",
@@ -3628,14 +3538,14 @@
     "address": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
     "symbol": "BLT",
     "decimals": 18,
-    "name": "Bloom",
-    "logo": "https://etherscan.io/token/images/hellobloom_28.png"
+    "name": "Bloom"
   },
   {
     "address": "0x08711D3B02C8758F2FB3ab4e80228418a7F8e39c",
     "symbol": "EDG",
     "decimals": 0,
-    "name": "Edgeless"
+    "name": "Edgeless",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/edg%402x.png"
   },
   {
     "address": "0x21f0F0fD3141Ee9E11B3d7f13a1028CD515f459c",
@@ -3659,14 +3569,14 @@
     "address": "0x0e0989b1f9B8A38983c2BA8053269Ca62Ec9B195",
     "symbol": "POE",
     "decimals": 8,
-    "name": "Po.et Tokens"
+    "name": "Po.et Tokens",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/poe%402x.png"
   },
   {
     "address": "0xF03f8D65BaFA598611C3495124093c56e8F638f0",
     "symbol": "VIEW",
     "decimals": 18,
-    "name": "Viewly",
-    "logo": "https://i.imgur.com/G285h1R.png"
+    "name": "Viewly"
   },
   {
     "address": "0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
@@ -3690,8 +3600,7 @@
     "address": "0xd9A8cfe21C232D485065cb62a96866799d4645f7",
     "symbol": "FGP",
     "decimals": 18,
-    "name": "FingerPrint",
-    "logo": "https://uploads-ssl.webflow.com/5b25dd6ef792a3021ba7c0d8/5b25e304a3234f9fdca9d06b_739.png"
+    "name": "FingerPrint"
   },
   {
     "address": "0x4f27053F32edA8Af84956437Bc00e5fFa7003287",
@@ -3721,8 +3630,7 @@
     "address": "0xe43ac1714F7394173b15E7CfF31A63d523Ce4fB9",
     "symbol": "PLS",
     "decimals": 18,
-    "name": "DACPLAY Token",
-    "logo": "https://imgland.oss-cn-hangzhou.aliyuncs.com/photo/2018/434e45cc-cbe6-4df2-b4d7-156b7ef78a8f.png"
+    "name": "DACPLAY Token"
   },
   {
     "address": "0x71D01dB8d6a2fBEa7f8d434599C237980C234e4C",
@@ -3746,8 +3654,7 @@
     "address": "0xBa7DCBa2Ade319Bc772DB4df75A76BA00dFb31b0",
     "symbol": "A18 (1)",
     "decimals": 0,
-    "name": "Apollo18",
-    "logo": "https://apollo18.co.in/wp-content/uploads/2018/08/a18-28x28.png"
+    "name": "Apollo18"
   },
   {
     "address": "0xBDe8f7820b5544a49D34F9dDeaCAbEDC7C0B5adc",
@@ -3777,8 +3684,7 @@
     "address": "0x7cf6dC769482AbEe2FF75795d000F381A8062DEC",
     "symbol": "FAR",
     "decimals": 18,
-    "name": "Far Token",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1552326624/far-logo-28x28.png"
+    "name": "Far Token"
   },
   {
     "address": "0x72430A612Adc007c50e3b6946dBb1Bb0fd3101D1",
@@ -3790,8 +3696,7 @@
     "address": "0x614b9802D45Aa1bC2282651dC1408632F9027A6e",
     "symbol": "TIC (Trust Invest)",
     "decimals": 18,
-    "name": "Trust Invest",
-    "logo": "https://trustinvest.io/images/logo.png"
+    "name": "Trust Invest"
   },
   {
     "address": "0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA",
@@ -3803,8 +3708,7 @@
     "address": "0x6710c63432A2De02954fc0f851db07146a6c0312",
     "symbol": "MFG",
     "decimals": 18,
-    "name": "SyncFab Smart Manufacturing Blockchain",
-    "logo": "https://blockchain.syncfab.com/assets/img/mfg-logo.png"
+    "name": "SyncFab Smart Manufacturing Blockchain"
   },
   {
     "address": "0xF3e014fE81267870624132ef3A646B8E83853a96",
@@ -3816,7 +3720,8 @@
     "address": "0x8eB24319393716668D768dCEC29356ae9CfFe285",
     "symbol": "AGI",
     "decimals": 8,
-    "name": "SingularityNET"
+    "name": "SingularityNET",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/agi%402x.png"
   },
   {
     "address": "0x41AB1b6fcbB2fA9DCEd81aCbdeC13Ea6315F2Bf2",
@@ -3828,8 +3733,7 @@
     "address": "0xc88Be04c809856B75E3DfE19eB4dCf0a3B15317a",
     "symbol": "BKC",
     "decimals": 8,
-    "name": "Bankcoin Cash",
-    "logo": "https://bankcoin-cash.com/bankcoincash.png"
+    "name": "Bankcoin Cash"
   },
   {
     "address": "0xd780Ae2Bf04cD96E577D3D014762f831d97129d0",
@@ -3853,35 +3757,33 @@
     "address": "0x4CF488387F035FF08c371515562CBa712f9015d4",
     "symbol": "WPR",
     "decimals": 18,
-    "name": "WePower Token"
+    "name": "WePower Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/wpr%402x.png"
   },
   {
     "address": "0x0235fE624e044A05eeD7A43E16E3083bc8A4287A",
     "symbol": "OCC",
     "decimals": 18,
-    "name": "Original Crypto Coin",
-    "logo": "https://originalcryptocoin.com/wp-content/uploads/2018/01/cc-black-500.png"
+    "name": "Original Crypto Coin"
   },
   {
     "address": "0x9bb1Db1445b83213a56d90d331894b3f26218e4e",
     "symbol": "HIBT",
     "decimals": 18,
-    "name": "HiBTC Token",
-    "logo": "https://www.hibtc.com/om/coin-icon/HIBT-28.png"
+    "name": "HiBTC Token"
   },
   {
     "address": "0x81c9151de0C8bafCd325a57E3dB5a5dF1CEBf79c",
     "symbol": "DAT",
     "decimals": 18,
     "name": "Datum Token",
-    "logo": "https://datum.org/assets/images/datumlogo_square_128px.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dat%402x.png"
   },
   {
     "address": "0x497bAEF294c11a5f0f5Bea3f2AdB3073DB448B56",
     "symbol": "DEX",
     "decimals": 18,
-    "name": "DEX",
-    "logo": "https://static.coinbit.co.kr/assets/img/coin/dex.png"
+    "name": "DEX"
   },
   {
     "address": "0x6e2050CBFB3eD8A4d39b64cC9f47E711a03a5a89",
@@ -3905,8 +3807,7 @@
     "address": "0x0DB8D8b76BC361bAcbB72E2C491E06085A97Ab31",
     "symbol": "IQN",
     "decimals": 18,
-    "name": "IQeon",
-    "logo": "https://s3.eu-central-1.amazonaws.com/iqeon-content/logo/4_5953844568075010913.png"
+    "name": "IQeon"
   },
   {
     "address": "0xc166038705FFBAb3794185b3a9D925632A1DF37D",
@@ -3918,8 +3819,7 @@
     "address": "0x03e3f0c25965f13DbbC58246738C183E27b26a56",
     "symbol": "DSCP",
     "decimals": 18,
-    "name": "Disciplina Token",
-    "logo": "https://disciplina.io/logo.png"
+    "name": "Disciplina Token"
   },
   {
     "address": "0x8a95ca448A52C0ADf0054bB3402dC5e09CD6B232",
@@ -3931,13 +3831,15 @@
     "address": "0x558EC3152e2eb2174905cd19AeA4e34A23DE9aD6",
     "symbol": "BRD",
     "decimals": 18,
-    "name": "Bread"
+    "name": "Bread",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/brd%402x.png"
   },
   {
     "address": "0xcbeAEc699431857FDB4d37aDDBBdc20E132D4903",
     "symbol": "YOYOW",
     "decimals": 18,
-    "name": "YOYOW"
+    "name": "YOYOW",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/yoyow%402x.png"
   },
   {
     "address": "0xeDBaF3c5100302dCddA53269322f3730b1F0416d",
@@ -3949,8 +3851,7 @@
     "address": "0x92E78dAe1315067a8819EFD6dCA432de9DCdE2e9",
     "symbol": "VRS (2)",
     "decimals": 6,
-    "name": "Veros",
-    "logo": "https://vedh.io/logo_128x128.png"
+    "name": "Veros"
   },
   {
     "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
@@ -3962,15 +3863,13 @@
     "address": "0xbD4AB8b9C26c4888e2792cAC6d5793Efea9eBb20",
     "symbol": "KRTY",
     "decimals": 18,
-    "name": "KARTIY",
-    "logo": "https://www.kartiy.com/logo.png"
+    "name": "KARTIY"
   },
   {
     "address": "0x0a9A9ce600D08BF9b76F49FA4e7b38A67EBEB1E6",
     "symbol": "GROW",
     "decimals": 8,
-    "name": "Growchain",
-    "logo": "http://www.growchain.us/data/logo.png"
+    "name": "Growchain"
   },
   {
     "address": "0x8727c112C712c4a03371AC87a74dD6aB104Af768",
@@ -3982,7 +3881,8 @@
     "address": "0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6",
     "symbol": "RDN",
     "decimals": 18,
-    "name": "Raiden Network"
+    "name": "Raiden Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rdn%402x.png"
   },
   {
     "address": "0xe469c4473af82217B30CF17b10BcDb6C8c796e75",
@@ -4006,8 +3906,7 @@
     "address": "0xb683D83a532e2Cb7DFa5275eED3698436371cc9f",
     "symbol": "BTU",
     "decimals": 18,
-    "name": "BTU Protocol",
-    "logo": "https://btu-protocol.com/fr/favicon/favicon-32x32.png"
+    "name": "BTU Protocol"
   },
   {
     "address": "0x2dAEE1AA61D60A252DC80564499A69802853583A",
@@ -4025,8 +3924,7 @@
     "address": "0x539EfE69bCDd21a83eFD9122571a64CC25e0282b",
     "symbol": "BLUE",
     "decimals": 8,
-    "name": "Ethereum Blue",
-    "logo": "https://s2.coinmarketcap.com/static/img/coins/32x32/2076.png"
+    "name": "Ethereum Blue"
   },
   {
     "address": "0x2e071D2966Aa7D8dECB1005885bA1977D6038A65",
@@ -4038,14 +3936,14 @@
     "address": "0x93E682107d1E9defB0b5ee701C71707a4B2E46Bc",
     "symbol": "MCAP",
     "decimals": 8,
-    "name": "MCAP"
+    "name": "MCAP",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mcap%402x.png"
   },
   {
     "address": "0x57C75ECCc8557136D32619a191fBCDc88560d711",
     "symbol": "VDG",
     "decimals": 0,
-    "name": "VeriDocGlobal",
-    "logo": "https://veridocglobal.com/Themes/veridoc/Content/img/logo.png"
+    "name": "VeriDocGlobal"
   },
   {
     "address": "0xFFAA5ffc455d9131f8A2713A741fD1960330508B",
@@ -4063,22 +3961,19 @@
     "address": "0x7dCB3B2356C822d3577D4d060D0D5D78C860488C",
     "symbol": "FANX (1)",
     "decimals": 18,
-    "name": "FANX Token",
-    "logo": "http://www.fanx.one/static/img/logo.png"
+    "name": "FANX Token"
   },
   {
     "address": "0x7f6715c3FC4740A02F70De85B9FD50ac6001fEd9",
     "symbol": "FANX (2)",
     "decimals": 18,
-    "name": "FANX Token",
-    "logo": "http://www.fanx.one/static/img/logo.png"
+    "name": "FANX Token"
   },
   {
     "address": "0x994f0DffdbaE0BbF09b652D6f11A493fd33F42B9",
     "symbol": "EAGLE",
     "decimals": 18,
-    "name": "EagleCoin",
-    "logo": "https://pasteboard.co/GYomPdv.jpg"
+    "name": "EagleCoin"
   },
   {
     "address": "0x264Dc2DedCdcbb897561A57CBa5085CA416fb7b4",
@@ -4096,15 +3991,13 @@
     "address": "0x0fF161071e627A0E6de138105C73970F86ca7922",
     "symbol": "PIT",
     "decimals": 18,
-    "name": "Paypite v2",
-    "logo": "https://paypite.org/wp-content/uploads/2018/04/Logo-paypite-Site-wordpress.png"
+    "name": "Paypite v2"
   },
   {
     "address": "0xF660cA1e228e7BE1fA8B4f5583145E31147FB577",
     "symbol": "CET",
     "decimals": 18,
-    "name": "DICE Money Dicet",
-    "logo": "https://www.dropbox.com/s/5ag9npp048m1qf0/logo_transparent_small.png?dl=0"
+    "name": "DICE Money Dicet"
   },
   {
     "address": "0x865ec58b06bF6305B886793AA20A2da31D034E68",
@@ -4128,8 +4021,7 @@
     "address": "0x9C9Fe3bD60b22A9735908B9589011E78F2025C11",
     "symbol": "HNST",
     "decimals": 18,
-    "name": "Honest",
-    "logo": "https://honestmining.github.io/hnst/HNST-128.png"
+    "name": "Honest"
   },
   {
     "address": "0x881Ef48211982D01E2CB7092C915E647Cd40D85C",
@@ -4165,8 +4057,7 @@
     "address": "0xCA0e7269600d353F70b14Ad118A49575455C0f2f",
     "symbol": "AMLT",
     "decimals": 18,
-    "name": "AMLT",
-    "logo": "https://s3.eu-west-2.amazonaws.com/amlt/AMLT_logo_mew.png"
+    "name": "AMLT"
   },
   {
     "address": "0xEE74110fB5A1007b06282e0DE5d73A61bf41d9Cd",
@@ -4178,8 +4069,7 @@
     "address": "0x4b96bf1feF93A216914fc843D81207A027ce52b3",
     "symbol": "VUU",
     "decimals": 18,
-    "name": "Vuulr Token",
-    "logo": "https://assets.vuulr.com/Vuulr-Logo_100x100T.png"
+    "name": "Vuulr Token"
   },
   {
     "address": "0x2A22e5cCA00a3D63308fa39f29202eB1b39eEf52",
@@ -4203,15 +4093,13 @@
     "address": "0x60C24407d01782C2175D32fe7C8921ed732371D1",
     "symbol": "LEMO (1)",
     "decimals": 18,
-    "name": "Lemo",
-    "logo": "https://lemochip.hellobyebye.com/logo.png"
+    "name": "Lemo"
   },
   {
     "address": "0xB5AE848EdB296C21259b7467331467d2647eEcDf",
     "symbol": "LEMO (2)",
     "decimals": 18,
-    "name": "Lemo",
-    "logo": "https://lemochip.hellobyebye.com/logo.png"
+    "name": "Lemo"
   },
   {
     "address": "0xd6e354F07319e2474491D8c7c712137bEe6862a2",
@@ -4235,7 +4123,8 @@
     "address": "0x90528aeb3a2B736B780fD1B6C478bB7E1d643170",
     "symbol": "XPA",
     "decimals": 18,
-    "name": "XPA"
+    "name": "XPA",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/xpa%402x.png"
   },
   {
     "address": "0x2C82c73d5B34AA015989462b2948cd616a37641F",
@@ -4259,8 +4148,7 @@
     "address": "0xC17195bde49D70CefCF8A9F2ee1759FFC27BF0B1",
     "symbol": "GROO",
     "decimals": 18,
-    "name": "Groocoin",
-    "logo": "https://cdn.staticaly.com/gh/TrustWallet/tokens/master/images/0xc17195bde49d70cefcf8a9f2ee1759ffc27bf0b1.png"
+    "name": "Groocoin"
   },
   {
     "address": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
@@ -4272,8 +4160,7 @@
     "address": "0xe3831c5A982B279A198456D577cfb90424cb6340",
     "symbol": "IMC",
     "decimals": 6,
-    "name": "Immune Coin",
-    "logo": "http://immunecoin.info/logo_32_32.png"
+    "name": "Immune Coin"
   },
   {
     "address": "0x1A0F2aB46EC630F9FD638029027b552aFA64b94c",
@@ -4291,7 +4178,8 @@
     "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
     "symbol": "DENT",
     "decimals": 8,
-    "name": "DENT"
+    "name": "DENT",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dent%402x.png"
   },
   {
     "address": "0xCb5ea3c190d8f82DEADF7ce5Af855dDbf33e3962",
@@ -4303,15 +4191,13 @@
     "address": "0x98F5e9b7F0e33956C0443E81bF7deB8B5b1ed545",
     "symbol": "SEXY",
     "decimals": 18,
-    "name": "Sexy Token",
-    "logo": "https://etherscan.io/token/images/sexytoken28.png"
+    "name": "Sexy Token"
   },
   {
     "address": "0x82BD526bDB718C6d4DD2291Ed013A5186cAE2DCa",
     "symbol": "VDOC",
     "decimals": 18,
-    "name": "Duty of Care Token",
-    "logo": "https://www.dutyof.care/assets/img/favicon.png"
+    "name": "Duty of Care Token"
   },
   {
     "address": "0xA54ddC7B3CcE7FC8b1E3Fa0256D0DB80D2c10970",
@@ -4335,8 +4221,7 @@
     "address": "0x001F0aA5dA15585e5b2305DbaB2bac425ea71007",
     "symbol": "IPSX",
     "decimals": 18,
-    "name": "IP Exchange",
-    "logo": "https://ip.sx/images/IPSX-Logo-28x28.png"
+    "name": "IP Exchange"
   },
   {
     "address": "0x0371A82e4A9d0A4312f3ee2Ac9c6958512891372",
@@ -4361,7 +4246,7 @@
     "symbol": "APPC",
     "decimals": 18,
     "name": "AppCoins",
-    "logo": "https://ibb.co/jFsGsG"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/appc%402x.png"
   },
   {
     "address": "0x779B7b713C86e3E6774f5040D9cCC2D43ad375F8",
@@ -4373,40 +4258,40 @@
     "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
     "symbol": "QSP",
     "decimals": 18,
-    "name": "Quantstamp Token"
+    "name": "Quantstamp Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/qsp%402x.png"
   },
   {
     "address": "0x039F5050dE4908f9b5ddF40A4F3Aa3f329086387",
     "symbol": "ENC",
     "decimals": 18,
-    "name": "Ethernet.Cash",
-    "logo": "https://ethernet.cash/images/logo28x28.png"
+    "name": "Ethernet.Cash"
   },
   {
     "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
     "symbol": "WBTC",
     "decimals": 8,
-    "name": "Wrapped Bitcoin",
-    "logo": "https://www.wbtc.network/assets/BitGo-favicon.ico"
+    "name": "Wrapped Bitcoin"
   },
   {
     "address": "0x1BC7C1dE0AC6eF4fDeC35c053030D90cf54c7e9A",
     "symbol": "YNN",
     "decimals": 18,
-    "name": "YANG",
-    "logo": "https://prnt.sc/mwg7ak"
+    "name": "YANG"
   },
   {
     "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
     "symbol": "DNT",
     "decimals": 18,
-    "name": "District0x Network Token"
+    "name": "District0x Network Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dnt%402x.png"
   },
   {
     "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
     "symbol": "STORJ",
     "decimals": 8,
-    "name": "STORJ"
+    "name": "STORJ",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/storj%402x.png"
   },
   {
     "address": "0x5e888B83B7287EED4fB7DA7b7d0A0D4c735d94b3",
@@ -4430,8 +4315,7 @@
     "address": "0x9501BFc48897DCEEadf73113EF635d2fF7ee4B97",
     "symbol": "EMT",
     "decimals": 18,
-    "name": "easyMINE Token",
-    "logo": "https://etherscan.io/token/images/easymine_28.png"
+    "name": "easyMINE Token"
   },
   {
     "address": "0x5e6016Ae7d7C49d347dcF834860B9f3Ee282812b",
@@ -4449,8 +4333,7 @@
     "address": "0x5bB1632fA0023e1AA76a1AE92B4635C8DBa49Fa2",
     "symbol": "FORK",
     "decimals": 18,
-    "name": "GastroAdvisorToken",
-    "logo": "https://www.gastroadvisor.com/wp-content/uploads/2019/02/Gastro_logo_black.png"
+    "name": "GastroAdvisorToken"
   },
   {
     "address": "0x3ADfc4999F77D04c8341BAC5F3A76f58DfF5B37A",
@@ -4474,14 +4357,14 @@
     "address": "0x957c30aB0426e0C93CD8241E2c60392d08c6aC8e",
     "symbol": "MOD",
     "decimals": 0,
-    "name": "Modum"
+    "name": "Modum",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mod%402x.png"
   },
   {
     "address": "0x1e49fF77c355A3e38D6651ce8404AF0E48c5395f",
     "symbol": "MTRc",
     "decimals": 18,
-    "name": "MTRCToken",
-    "logo": "https://en.modultrade.io/img/new_set/modultrade_logo.svg"
+    "name": "MTRCToken"
   },
   {
     "address": "0x4aF328C52921706dCB739F25786210499169AFe6",
@@ -4499,8 +4382,7 @@
     "address": "0xc73f2474001aD1D6aEd615aF53631148CF98dE6b",
     "symbol": "BAR",
     "decimals": 18,
-    "name": "Billionaire Ambition",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1552755402/bar-logo-128x128.png"
+    "name": "Billionaire Ambition"
   },
   {
     "address": "0x1B5f21ee98eed48d292e8e2d3Ed82b40a9728A22",
@@ -4513,7 +4395,7 @@
     "symbol": "FUEL",
     "decimals": 18,
     "name": "Etherparty FUEL",
-    "logo": "https://image.ibb.co/mzeWD6/EP3_Blue.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/fuel%402x.png"
   },
   {
     "address": "0xE8F9fa977ea585591d9F394681318C16552577fB",
@@ -4531,7 +4413,8 @@
     "address": "0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206",
     "symbol": "NEXO",
     "decimals": 18,
-    "name": "Nexo"
+    "name": "Nexo",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/nexo%402x.png"
   },
   {
     "address": "0x4AaC461C86aBfA71e9d00d9a2cde8d74E4E1aeEa",
@@ -4567,8 +4450,7 @@
     "address": "0xFADe17a07ba3B480aA1714c3724a52D4C57d410E",
     "symbol": "VEGAN",
     "decimals": 8,
-    "name": "Vegan",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1550925563/vegan-logo-28x28.png"
+    "name": "Vegan"
   },
   {
     "address": "0x6745fAB6801e376cD24F03572B9C9B0D4EdDDCcf",
@@ -4598,22 +4480,20 @@
     "address": "0x4D8fc1453a0F359e99c9675954e656D80d996FbF",
     "symbol": "BEE",
     "decimals": 18,
-    "name": "Bee Token",
-    "logo": "https://etherscan.io/token/images/beetoken_28.png"
+    "name": "Bee Token"
   },
   {
     "address": "0xfbd0d1c77B501796A35D86cF91d65D9778EeE695",
     "symbol": "TWNKL",
     "decimals": 3,
-    "name": "Twinkle",
-    "logo": "https://www.rainbowcurrency.com/new/assets/img/logo_full2.jpg"
+    "name": "Twinkle"
   },
   {
     "address": "0xE638dc39b6aDBEE8526b5C22380b4b45dAf46d8e",
     "symbol": "GZR",
     "decimals": 6,
     "name": "Gizer",
-    "logo": "https://etherscan.io/token/images/gizer2_28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gzr%402x.png"
   },
   {
     "address": "0xA849EaaE994fb86Afa73382e9Bd88c2B6b18Dc71",
@@ -4655,21 +4535,20 @@
     "address": "0xe7E4279b80D319EDe2889855135A22021baf0907",
     "symbol": "ZEUS",
     "decimals": 18,
-    "name": "ZeusNetwork",
-    "logo": "https://zeusfundme.com/wp-content/uploads/2018/10/website-logo-e1540768468436.png"
+    "name": "ZeusNetwork"
   },
   {
     "address": "0x51DB5Ad35C671a87207d88fC11d593AC0C8415bd",
     "symbol": "MDA",
     "decimals": 18,
-    "name": "Moeda Loyalty Points"
+    "name": "Moeda Loyalty Points",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mda%402x.png"
   },
   {
     "address": "0xBC86727E770de68B1060C91f6BB6945c73e10388",
     "symbol": "XNK",
     "decimals": 18,
-    "name": "Ink Protocol",
-    "logo": "https://etherscan.io/token/images/paywithink_28.png"
+    "name": "Ink Protocol"
   },
   {
     "address": "0x0D262e5dC4A06a0F1c90cE79C7a60C09DfC884E4",
@@ -4687,8 +4566,7 @@
     "address": "0x9DAe8b7F6D37ea8e5d32C6c3E856a6d8a1d3B363",
     "symbol": "GZB",
     "decimals": 18,
-    "name": "GigziBlack",
-    "logo": "https://gigzi.com/assets/crypto-assets-block/icon_gzb.svg"
+    "name": "GigziBlack"
   },
   {
     "address": "0x378903a03FB2C3AC76BB52773e3CE11340377A32",
@@ -4700,14 +4578,14 @@
     "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
     "symbol": "RLC",
     "decimals": 9,
-    "name": "IEx.ec"
+    "name": "IEx.ec",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rlc%402x.png"
   },
   {
     "address": "0xBFbe5332f172d77811bC6c272844f3e54A7B23bB",
     "symbol": "WMK",
     "decimals": 18,
-    "name": "WemarkToken",
-    "logo": "https://cdn.wemark.com/wmk-logo-250.png"
+    "name": "WemarkToken"
   },
   {
     "address": "0xC4Bcd64CB216D49fD3C643A32762F34626b45a1a",
@@ -4743,14 +4621,14 @@
     "address": "0xA4Bdb11dc0a2bEC88d24A3aa1E6Bb17201112eBe",
     "symbol": "USDS",
     "decimals": 6,
-    "name": "StableUSD",
-    "logo": "https://www.stably.io/static/images/meta/favicons/favicon.ico"
+    "name": "StableUSD"
   },
   {
     "address": "0x8b353021189375591723E7384262F45709A3C3dC",
     "symbol": "TOMO",
     "decimals": 18,
-    "name": "Tomocoin"
+    "name": "Tomocoin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tomo%402x.png"
   },
   {
     "address": "0xBEB9eF514a379B997e0798FDcC901Ee474B6D9A1",
@@ -4780,14 +4658,14 @@
     "address": "0xE7775A6e9Bcf904eb39DA2b68c5efb4F9360e08C",
     "symbol": "TaaS",
     "decimals": 6,
-    "name": "Token-as-a-Service"
+    "name": "Token-as-a-Service",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/taas%402x.png"
   },
   {
     "address": "0x9aeFBE0b3C3ba9Eab262CB9856E8157AB7648e09",
     "symbol": "FLR",
     "decimals": 18,
-    "name": "Flair Coin",
-    "logo": "https://flaircoin.co/assets/images/flair_logo_64x64.png"
+    "name": "Flair Coin"
   },
   {
     "address": "0x44F588aEeB8C44471439D1270B3603c66a9262F1",
@@ -4799,8 +4677,7 @@
     "address": "0x17f8aFB63DfcDcC90ebE6e84F060Cc306A98257D",
     "symbol": "NBAI",
     "decimals": 18,
-    "name": "NebulaAiToken",
-    "logo": "https://tokensale.nebula-ai.network/ressources/images/1801349612.jpg"
+    "name": "NebulaAiToken"
   },
   {
     "address": "0x2accaB9cb7a48c3E82286F0b2f8798D201F4eC3f",
@@ -4836,14 +4713,15 @@
     "address": "0xb2F7EB1f2c37645bE61d73953035360e768D81E6",
     "symbol": "COB",
     "decimals": 18,
-    "name": "Cobinhood Token"
+    "name": "Cobinhood Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cob%402x.png"
   },
   {
     "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
     "symbol": "PAX",
     "decimals": 18,
     "name": "Paxos Standard (PAX)",
-    "logo": "https://static.standard.paxos.com/logos/square_120_120.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/pax%402x.png"
   },
   {
     "address": "0x5A567e28dbFa2bBD3ef13C0a01be114745349657",
@@ -4855,8 +4733,7 @@
     "address": "0x829A4cA1303383F1082B6B1fB937116e4b3b5605",
     "symbol": "WATT",
     "decimals": 18,
-    "name": "WorkChain App Token",
-    "logo": "https://workchain.io/downloads/workTOKEN/logo_128.png"
+    "name": "WorkChain App Token"
   },
   {
     "address": "0xFB12e3CcA983B9f59D90912Fd17F8D745A8B2953",
@@ -4868,15 +4745,13 @@
     "address": "0x0db03B6CDe0B2d427C64a04FeAfd825938368f1F",
     "symbol": "PDATA",
     "decimals": 18,
-    "name": "PDATA",
-    "logo": "https://www.opiria.io/static/images/logo-solo.png"
+    "name": "PDATA"
   },
   {
     "address": "0x2108E62D335Bbdc89eC3E9d8582F18DCFB0cDFf4",
     "symbol": "CARCO",
     "decimals": 8,
-    "name": "CARCO",
-    "logo": "https://image.ibb.co/mEQjbw/CARCO_crypto_logo.png"
+    "name": "CARCO"
   },
   {
     "address": "0xF03045a4C8077e38f3B8e2Ed33b8aEE69edF869F",
@@ -4924,15 +4799,13 @@
     "address": "0x7939882b54fcf0bCAe6b53dEc39Ad6e806176442",
     "symbol": "MKT",
     "decimals": 8,
-    "name": "Mikado",
-    "logo": "https://avatars3.githubusercontent.com/u/38851395?s=400"
+    "name": "Mikado"
   },
   {
     "address": "0x9c23D67AEA7B95D80942e3836BCDF7E708A747C2",
     "symbol": "LOCI",
     "decimals": 18,
-    "name": "LOCIcoin",
-    "logo": "https://locipro.com/assets/loci-28x28.png"
+    "name": "LOCIcoin"
   },
   {
     "address": "0x3eb91D237e491E0DEE8582c402D85CB440fb6b54",
@@ -4998,15 +4871,13 @@
     "address": "0xEf6B4cE8C9Bc83744fbcdE2657b32eC18790458A",
     "symbol": "PUC",
     "decimals": 0,
-    "name": "Pour Coin",
-    "logo": "http://price-s.info/wp-content/uploads/2018/01/p.png"
+    "name": "Pour Coin"
   },
   {
     "address": "0x763186eB8d4856D536eD4478302971214FEbc6A9",
     "symbol": "BETR",
     "decimals": 18,
-    "name": "BetterBetting",
-    "logo": "https://betterbetting.org/assets/images/bb-token-icon_w28.png"
+    "name": "BetterBetting"
   },
   {
     "address": "0xc14830E53aA344E8c14603A91229A0b925b0B262",
@@ -5018,8 +4889,7 @@
     "address": "0x286708f069225905194673755F12359e6afF6FE1",
     "symbol": "STACS",
     "decimals": 18,
-    "name": "STACS",
-    "logo": "https://www.dropbox.com/s/2tasnbaowu8s8pf/STACS_200x200.png?raw=1"
+    "name": "STACS"
   },
   {
     "address": "0xEA610B1153477720748DC13ED378003941d84fAB",
@@ -5037,8 +4907,7 @@
     "address": "0x64A60493D888728Cf42616e034a0dfEAe38EFCF0",
     "symbol": "OLT",
     "decimals": 18,
-    "name": "OneLedger Token",
-    "logo": "https://etherscan.io/token/images/oneledger_28.png"
+    "name": "OneLedger Token"
   },
   {
     "address": "0x05C3617cBf1304b9260AA61ec960F115D67beCEA",
@@ -5051,7 +4920,7 @@
     "symbol": "ENTRP",
     "decimals": 18,
     "name": "Hut34 Entropy Token",
-    "logo": "https://hut34.io/images/comms/Hut34-logo-orange.jpg"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/entrp%402x.png"
   },
   {
     "address": "0x54b293226000ccBFC04DF902eEC567CB4C35a903",
@@ -5075,36 +4944,31 @@
     "address": "0x5e8F855966D638135a968861E80DdA722291B06d",
     "symbol": "COIN (Coinvest V2 Token)",
     "decimals": 18,
-    "name": "Coinvest V2 Token",
-    "logo": "https://coinve.st/assets/images/Coinvest_Profile.png"
+    "name": "Coinvest V2 Token"
   },
   {
     "address": "0xeb547ed1D8A3Ff1461aBAa7F0022FED4836E00A4",
     "symbol": "COIN (Coinvest V3 Token)",
     "decimals": 18,
-    "name": "Coinvest V3 Token",
-    "logo": "https://coinve.st/assets/images/Coinvest_Profile.png"
+    "name": "Coinvest V3 Token"
   },
   {
     "address": "0xa33e729bf4fdeb868B534e1f20523463D9C46bEe",
     "symbol": "ICO",
     "decimals": 10,
-    "name": "ICO",
-    "logo": "https://etherscan.io/token/images/icocoin_28.png"
+    "name": "ICO"
   },
   {
     "address": "0xA3149E0fA0061A9007fAf307074cdCd290f0e2Fd",
     "symbol": "PRON",
     "decimals": 8,
-    "name": "PronCoin",
-    "logo": "https://pbs.twimg.com/profile_images/943518409899302912/_qB2ilhB_400x400.jpg"
+    "name": "PronCoin"
   },
   {
     "address": "0xAbdf147870235FcFC34153828c769A70B3FAe01F",
     "symbol": "EURT",
     "decimals": 6,
-    "name": "EUR Tether (erc20)",
-    "logo": "https://etherscan.io/token/images/tether-euro_28.png"
+    "name": "EUR Tether (erc20)"
   },
   {
     "address": "0xC64500DD7B0f1794807e67802F8Abbf5F8Ffb054",
@@ -5116,8 +4980,7 @@
     "address": "0xE50365f5D679CB98a1dd62D6F6e58e59321BcdDf",
     "symbol": "LA",
     "decimals": 18,
-    "name": "LATOKEN",
-    "logo": "https://cdn.latoken.com/common/img/logo.svg"
+    "name": "LATOKEN"
   },
   {
     "address": "0xD850942eF8811f2A866692A623011bDE52a462C1",
@@ -5141,7 +5004,8 @@
     "address": "0x08f5a9235B08173b7569F83645d2c7fB55e8cCD8",
     "symbol": "TNT",
     "decimals": 8,
-    "name": "Tierion Network Token"
+    "name": "Tierion Network Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tnt%402x.png"
   },
   {
     "address": "0x5121E348e897dAEf1Eef23959Ab290e5557CF274",
@@ -5207,7 +5071,8 @@
     "address": "0x327682779bAB2BF4d1337e8974ab9dE8275A7Ca8",
     "symbol": "BPT",
     "decimals": 18,
-    "name": "Blockport Token"
+    "name": "Blockport Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bpt%402x.png"
   },
   {
     "address": "0x8a854288a5976036A725879164Ca3e91d30c6A1B",
@@ -5279,35 +5144,33 @@
     "address": "0x9fC0583220eB44fAeE9e2dc1E63F39204DDD9090",
     "symbol": "2DC",
     "decimals": 18,
-    "name": "DualChain",
-    "logo": "https://image.ibb.co/iniG4c/282541262323.png"
+    "name": "DualChain"
   },
   {
     "address": "0x8D75959f1E61EC2571aa72798237101F084DE63a",
     "symbol": "SUB",
     "decimals": 18,
     "name": "Substratum",
-    "logo": "https://substratum.net/wp-content/uploads/2019/02/Substratum-Logo-128x128.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/sub%402x.png"
   },
   {
     "address": "0xe6f74dcfa0E20883008d8C16b6d9a329189D0C30",
     "symbol": "FTC",
     "decimals": 2,
-    "name": "FTC"
+    "name": "FTC",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ftc%402x.png"
   },
   {
     "address": "0x6888a16eA9792c15A4DCF2f6C623D055c8eDe792",
     "symbol": "SIG",
     "decimals": 18,
-    "name": "Signal",
-    "logo": "https://uploads-ssl.webflow.com/58fd371467a8320d4f29aed3/5906667d95a2d43d31378ce7_60x60logo.png"
+    "name": "Signal"
   },
   {
     "address": "0x444997b7e7fC830E20089afea3078cd518fCF2A2",
     "symbol": "EWO",
     "decimals": 18,
-    "name": "EWO Token",
-    "logo": "https://www.ewoplace.com/images/EWO-Token-Icon-256px-min.png"
+    "name": "EWO Token"
   },
   {
     "address": "0x01b3Ec4aAe1B8729529BEB4965F27d008788B0EB",
@@ -5343,7 +5206,8 @@
     "address": "0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d",
     "symbol": "MCO",
     "decimals": 8,
-    "name": "Crypto.com"
+    "name": "Crypto.com",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mco%402x.png"
   },
   {
     "address": "0x3543638eD4a9006E4840B105944271Bcea15605D",
@@ -5367,7 +5231,8 @@
     "address": "0xaF4DcE16Da2877f8c9e00544c93B62Ac40631F16",
     "symbol": "MTH",
     "decimals": 5,
-    "name": "Monetha"
+    "name": "Monetha",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mth%402x.png"
   },
   {
     "address": "0xC66eA802717bFb9833400264Dd12c2bCeAa34a6d",
@@ -5385,8 +5250,7 @@
     "address": "0x0a1D2fF7156a48131553CF381F220bbedB4eFa37",
     "symbol": "FABA",
     "decimals": 18,
-    "name": "FABA",
-    "logo": "https://www.faba-white-paper.com/logo.png"
+    "name": "FABA"
   },
   {
     "address": "0x198A87b3114143913d4229Fb0f6D4BCb44aa8AFF",
@@ -5404,15 +5268,14 @@
     "address": "0x2ecB13A8c458c379c4d9a7259e202De03c8F3D19",
     "symbol": "BC",
     "decimals": 18,
-    "name": "Block-Chain.com",
-    "logo": "https://www.dropbox.com/s/quqlk3xywx6982r/BC.png"
+    "name": "Block-Chain.com"
   },
   {
     "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     "symbol": "USDT",
     "decimals": 6,
     "name": "USD Tether (erc20)",
-    "logo": "https://etherscan.io/token/images/tether28_2.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/usdt%402x.png"
   },
   {
     "address": "0x4cE6B362Bc77A24966Dda9078f9cEF81b3B886a7",
@@ -5430,8 +5293,7 @@
     "address": "0xdEE02D94be4929d26f67B64Ada7aCf1914007F10",
     "symbol": "RUNE",
     "decimals": 18,
-    "name": "Rune",
-    "logo": "https://tinypng.com/web/output/p37b6xpd2grdza41jqd52qftd20ukz0r/Rune%20128x128.png"
+    "name": "Rune"
   },
   {
     "address": "0x1dEa979ae76f26071870F824088dA78979eb91C8",
@@ -5443,8 +5305,7 @@
     "address": "0x76960Dccd5a1fe799F7c29bE9F19ceB4627aEb2f",
     "symbol": "RED",
     "decimals": 18,
-    "name": "Red Community Token",
-    "logo": "https://static.red-lang.org/pr/logo/red-token-logo_sq_128x128.png"
+    "name": "Red Community Token"
   },
   {
     "address": "0x61725f3db4004AFE014745B21DAb1E1677CC328b",
@@ -5456,8 +5317,7 @@
     "address": "0x931684139f756C24eC0731E9F74FE50e5548dDeF",
     "symbol": "URB",
     "decimals": 18,
-    "name": "Urbit Data",
-    "logo": "https://urbitdata.io/blog/wp-content/uploads/2018/08/urbit-final-128x128.png"
+    "name": "Urbit Data"
   },
   {
     "address": "0xF0da1186a4977226b9135d0613ee72e229EC3F4d",
@@ -5469,8 +5329,7 @@
     "address": "0x13DB74B3cf512F65C4b91683940B4f3955E05085",
     "symbol": "SKE",
     "decimals": 8,
-    "name": "Super Keep Token",
-    "logo": "http://app.superkeep.cn/DataCenter/upload/admin/image/currency/0x13db74b3cf512f65c4b91683940b4f3955e05085.png"
+    "name": "Super Keep Token"
   },
   {
     "address": "0x27695E09149AdC738A978e9A678F99E4c39e9eb9",
@@ -5494,15 +5353,14 @@
     "address": "0xb1c1Cb8C7c1992dba24e628bF7d38E71daD46aeB",
     "symbol": "CLB",
     "decimals": 18,
-    "name": "Cloudbric",
-    "logo": "https://uploads-ssl.webflow.com/5ad9bd61b926b5696f03050f/5ad9bdd84bee8e3cee66af78_CLB_symbol_white%20(1).png"
+    "name": "Cloudbric"
   },
   {
     "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
     "symbol": "LPT",
     "decimals": 18,
     "name": "Livepeer Token",
-    "logo": "https://livepeer-dev.s3.amazonaws.com/logos/lpt_transparent_200.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/lpt%402x.png"
   },
   {
     "address": "0x399A0e6FbEb3d74c85357439f4c8AeD9678a5cbF",
@@ -5520,8 +5378,7 @@
     "address": "0x5512e1D6A7BE424b4323126B4f9E86D023F95764",
     "symbol": "PTWO",
     "decimals": 18,
-    "name": "PornTokenV2",
-    "logo": "https://www.porntoken.io/PorntokenV2.256.png"
+    "name": "PornTokenV2"
   },
   {
     "address": "0xcbCC0F036ED4788F63FC0fEE32873d6A7487b908",
@@ -5551,15 +5408,13 @@
     "address": "0x1961B3331969eD52770751fC718ef530838b6dEE",
     "symbol": "BDG",
     "decimals": 18,
-    "name": "BitDegree Token",
-    "logo": "https://raw.githubusercontent.com/bitdegree/banners/master/logos/2515x3285_letter_black.png"
+    "name": "BitDegree Token"
   },
   {
     "address": "0x45eDb535942a8C84D9f4b5D37e1b25F91Ea4804c",
     "symbol": "RAO",
     "decimals": 18,
-    "name": "RadioYo",
-    "logo": "https://raw.githubusercontent.com/gharshr/ICO_smartcontract/master/RAO_Token.png"
+    "name": "RadioYo"
   },
   {
     "address": "0xEee2d00Eb7DEB8Dd6924187f5AA3496B7d06E62A",
@@ -5571,8 +5426,7 @@
     "address": "0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0",
     "symbol": "KRL",
     "decimals": 18,
-    "name": "Kryll",
-    "logo": "https://kryll.io/external/K_256px.png"
+    "name": "Kryll"
   },
   {
     "address": "0x2023DCf7c438c8C8C0B0F28dBaE15520B4f3Ee20",
@@ -5584,8 +5438,7 @@
     "address": "0xb056c38f6b7Dc4064367403E26424CD2c60655e1",
     "symbol": "CEEK",
     "decimals": 18,
-    "name": "CEEK VR Token",
-    "logo": "https://www.ceek.io/wp-content/uploads/2018/04/coin.png"
+    "name": "CEEK VR Token"
   },
   {
     "address": "0x85089389C14Bd9c77FC2b8F0c3d1dC3363Bf06Ef",
@@ -5609,7 +5462,8 @@
     "address": "0x5d65D971895Edc438f465c17DB6992698a52318D",
     "symbol": "NAS",
     "decimals": 18,
-    "name": "Nebula"
+    "name": "Nebula",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/nas%402x.png"
   },
   {
     "address": "0x4c383bDCae52a6e1cb810C76C70d6f31A249eC9B",
@@ -5621,14 +5475,14 @@
     "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
     "symbol": "ZRX",
     "decimals": 18,
-    "name": "0x Project"
+    "name": "0x Project",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/zrx%402x.png"
   },
   {
     "address": "0x4a6058666cf1057eaC3CD3A5a614620547559fc9",
     "symbol": "BBK",
     "decimals": 18,
-    "name": "BRICKBLOCK TOKEN",
-    "logo": "https://www.brickblock.io/images/bb_logo_white.svg?crc=205463457"
+    "name": "BRICKBLOCK TOKEN"
   },
   {
     "address": "0x0D6DD9f68d24EC1d5fE2174f3EC8DAB52B52BaF5",
@@ -5670,7 +5524,8 @@
     "address": "0x46b9Ad944d1059450Da1163511069C718F699D31",
     "symbol": "CS",
     "decimals": 6,
-    "name": "Credits"
+    "name": "Credits",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/cs%402x.png"
   },
   {
     "address": "0x14F37B574242D366558dB61f3335289a5035c506",
@@ -5700,8 +5555,7 @@
     "address": "0xE3Fa177AcecfB86721Cf6f9f4206bd3Bd672D7d5",
     "symbol": "CTT",
     "decimals": 18,
-    "name": "ChainTrade Token",
-    "logo": "https://chaintrade.net/wp-content/uploads/2017/09/chaintrade-logo-600x600.png"
+    "name": "ChainTrade Token"
   },
   {
     "address": "0xE5a7c12972f3bbFe70ed29521C8949b8Af6a0970",
@@ -5725,8 +5579,7 @@
     "address": "0xC1E2097d788d33701BA3Cc2773BF67155ec93FC4",
     "symbol": "IAD",
     "decimals": 18,
-    "name": "IADOWR Coin",
-    "logo": "https://www.iadowrcoin.com/img/iadowrcoin.png"
+    "name": "IADOWR Coin"
   },
   {
     "address": "0xfd1e80508F243E64CE234eA88A5Fd2827c71D4b7",
@@ -5756,8 +5609,7 @@
     "address": "0x13cb85823f78Cff38f0B0E90D3e975b8CB3AAd64",
     "symbol": "REMI",
     "decimals": 18,
-    "name": "REMI",
-    "logo": "https://s3-ap-northeast-1.amazonaws.com/bluepan-token/remiit/remi_token_logo.png"
+    "name": "REMI"
   },
   {
     "address": "0x8Ae56a6850a7cbeaC3c3Ab2cB311e7620167eAC8",
@@ -5769,7 +5621,8 @@
     "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
     "symbol": "GUSD",
     "decimals": 2,
-    "name": "Gemini dollar"
+    "name": "Gemini dollar",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gusd%402x.png"
   },
   {
     "address": "0xf04a8ac553FceDB5BA99A64799155826C136b0Be",
@@ -5781,8 +5634,7 @@
     "address": "0xB22c2786a549B008517B67625f5296E8fAf9589e",
     "symbol": "BRP",
     "decimals": 18,
-    "name": "Rental Processor Token",
-    "logo": "https://bitherplatform.io/images/logo/BRP.png"
+    "name": "Rental Processor Token"
   },
   {
     "address": "0x1CCAA0F2a7210d76E1fDec740d5F323E2E1b1672",
@@ -5806,7 +5658,8 @@
     "address": "0xEF68e7C694F40c8202821eDF525dE3782458639f",
     "symbol": "LRC",
     "decimals": 18,
-    "name": "Loopring"
+    "name": "Loopring",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/lrc%402x.png"
   },
   {
     "address": "0x6927C69fb4daf2043fbB1Cb7b86c5661416bea29",
@@ -5836,8 +5689,7 @@
     "address": "0x71e8d74fF1C923E369D0e70DFb09866629C4DD35",
     "symbol": "WRK",
     "decimals": 18,
-    "name": "WorkCoin",
-    "logo": "https://workcoin.net/images/workcoin_logo.svg"
+    "name": "WorkCoin"
   },
   {
     "address": "0x3c4a3ffd813a107febd57B2f01BC344264D90FdE",
@@ -5855,7 +5707,8 @@
     "address": "0x4CEdA7906a5Ed2179785Cd3A40A69ee8bc99C466",
     "symbol": "AION",
     "decimals": 8,
-    "name": "Aion"
+    "name": "Aion",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/aion%402x.png"
   },
   {
     "address": "0xAc709FcB44a43c35F0DA4e3163b117A17F3770f5",
@@ -5873,15 +5726,13 @@
     "address": "0x8e5afc69f6227A3ad75eD346c8723Bc62ce97123",
     "symbol": "UMKA (1)",
     "decimals": 4,
-    "name": "UMKA",
-    "logo": "https://cdn-images-1.medium.com/fit/c/200/200/1*2qbLwo61-mobpkNCWeBcLQ.jpeg"
+    "name": "UMKA"
   },
   {
     "address": "0x105d97ef2E723f1cfb24519Bc6fF15a6D091a3F1",
     "symbol": "UMKA (2)",
     "decimals": 4,
-    "name": "UMKA",
-    "logo": "https://cdn-images-1.medium.com/fit/c/200/200/1*2qbLwo61-mobpkNCWeBcLQ.jpeg"
+    "name": "UMKA"
   },
   {
     "address": "0x694404595e3075A942397F466AAcD462FF1a7BD0",
@@ -5899,7 +5750,8 @@
     "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
     "symbol": "MANA",
     "decimals": 18,
-    "name": "Decentraland MANA"
+    "name": "Decentraland MANA",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mana%402x.png"
   },
   {
     "address": "0x5DBAC24e98E2a4f43ADC0DC82Af403fca063Ce2c",
@@ -5911,7 +5763,8 @@
     "address": "0xA823E6722006afe99E91c30FF5295052fe6b8E32",
     "symbol": "NEU",
     "decimals": 18,
-    "name": "NEU Fund"
+    "name": "NEU Fund",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/neu%402x.png"
   },
   {
     "address": "0x64CdF819d3E75Ac8eC217B3496d7cE167Be42e80",
@@ -5923,27 +5776,27 @@
     "address": "0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e",
     "symbol": "ELF",
     "decimals": 18,
-    "name": "ELF Token"
+    "name": "ELF Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/elf%402x.png"
   },
   {
     "address": "0xd8950fDeaa10304B7A7Fd03a2FC66BC39f3c711a",
     "symbol": "WYS",
     "decimals": 18,
-    "name": "wystoken",
-    "logo": "https://ibb.co/hmP1vo"
+    "name": "wystoken"
   },
   {
     "address": "0x170b275CEd089FffAEBFe927F445a350ED9160DC",
     "symbol": "OWN",
     "decimals": 8,
-    "name": "OWNDATA",
-    "logo": "https://owndata.network/assets/front/images/favicon/android-icon-28x28.png"
+    "name": "OWNDATA"
   },
   {
     "address": "0x622dFfCc4e83C64ba959530A5a5580687a57581b",
     "symbol": "AUTO",
     "decimals": 18,
-    "name": "Cube"
+    "name": "Cube",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/auto%402x.png"
   },
   {
     "address": "0xEcE83617Db208Ad255Ad4f45Daf81E25137535bb",
@@ -5955,7 +5808,8 @@
     "address": "0x701C244b988a513c945973dEFA05de933b23Fe1D",
     "symbol": "OAX",
     "decimals": 18,
-    "name": "OAX"
+    "name": "OAX",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/oax%402x.png"
   },
   {
     "address": "0x02F2D4a04E6E01aCE88bD2Cd632875543b2eF577",
@@ -5967,8 +5821,7 @@
     "address": "0x08b4c866aE9D1bE56a06e0C302054B4FFe067b43",
     "symbol": "BITCAR",
     "decimals": 8,
-    "name": "BitCar Token",
-    "logo": "https://raw.githubusercontent.com/BitCar-io/logos/master/crestlogo128x128.png"
+    "name": "BitCar Token"
   },
   {
     "address": "0x2A05d22DB079BC40C2f77a1d1fF703a56E631cc1",
@@ -5980,22 +5833,19 @@
     "address": "0x78fE18e41f436e1981a3a60D1557c8a7a9370461",
     "symbol": "SCANDI",
     "decimals": 2,
-    "name": "Scandiweb Coin",
-    "logo": "https://i.imgur.com/KrgWBxm.jpg"
+    "name": "Scandiweb Coin"
   },
   {
     "address": "0x92A5B04D0ED5D94D7a193d1d334D3D16996f4E13",
     "symbol": "ERT",
     "decimals": 18,
-    "name": "Eristica",
-    "logo": "https://eristica.com/eristica_red_128.png"
+    "name": "Eristica"
   },
   {
     "address": "0x6425c6BE902d692AE2db752B3c268AFAdb099D3b",
     "symbol": "MWAT",
     "decimals": 18,
-    "name": "RED MWAT",
-    "logo": "https://restartenergy.io/images/re-logo.png"
+    "name": "RED MWAT"
   },
   {
     "address": "0x8dB54ca569D3019A2ba126D03C37c44b5eF81EF6",
@@ -6013,8 +5863,7 @@
     "address": "0x28d7F432d24ba6020d1cbD4f28BEDc5a82F24320",
     "symbol": "TCNX",
     "decimals": 18,
-    "name": "Tercet Network",
-    "logo": "http://tercet.network/180Logo.jpg"
+    "name": "Tercet Network"
   },
   {
     "address": "0xBB49A51Ee5a66ca3a8CbE529379bA44Ba67E6771",
@@ -6033,7 +5882,7 @@
     "symbol": "NPXS",
     "decimals": 18,
     "name": "Pundi X Token",
-    "logo": "https://pundix.com/logo/logo.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/npxs%402x.png"
   },
   {
     "address": "0xbc1234552EBea32B5121190356bBa6D3Bb225bb5",
@@ -6045,15 +5894,13 @@
     "address": "0xaaB606817809841E8b1168be8779Eeaf6744Ef64",
     "symbol": "TTA",
     "decimals": 18,
-    "name": "Tend Token",
-    "logo": "https://miro.medium.com/fit/c/128/128/1*XcCWcqLz5_WVOnz9JD1Cdg.png"
+    "name": "Tend Token"
   },
   {
     "address": "0xC16b542ff490e01fcc0DC58a60e1EFdc3e357cA6",
     "symbol": "ROCK2",
     "decimals": 0,
-    "name": "ICE ROCK MINING",
-    "logo": "https://rockmining.blob.core.windows.net/logo/fullLogo.png"
+    "name": "ICE ROCK MINING"
   },
   {
     "address": "0x4A42d2c580f83dcE404aCad18dab26Db11a1750E",
@@ -6065,13 +5912,15 @@
     "address": "0xF970b8E36e23F7fC3FD752EeA86f8Be8D83375A6",
     "symbol": "RCN",
     "decimals": 18,
-    "name": "Ripio Credit Network"
+    "name": "Ripio Credit Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rcn%402x.png"
   },
   {
     "address": "0x1844b21593262668B7248d0f57a220CaaBA46ab9",
     "symbol": "PRL",
     "decimals": 18,
-    "name": "Oyster Pearl"
+    "name": "Oyster Pearl",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/prl%402x.png"
   },
   {
     "address": "0x9389434852b94bbaD4c8AfEd5B7BDBc5Ff0c2275",
@@ -6089,21 +5938,20 @@
     "address": "0x62D4c04644314F35868Ba4c65cc27a77681dE7a9",
     "symbol": "DRVH",
     "decimals": 18,
-    "name": "Driveholic Token",
-    "logo": "https://airdrop.driveholic.com/icon/apple-icon-180x180.png"
+    "name": "Driveholic Token"
   },
   {
     "address": "0x4C0fBE1BB46612915E7967d2C3213cd4d87257AD",
     "symbol": "APIS",
     "decimals": 18,
-    "name": "APIS",
-    "logo": "https://apisplatform.io/img/icon_250.png"
+    "name": "APIS"
   },
   {
     "address": "0xb7cB1C96dB6B22b0D3d9536E0108d062BD488F74",
     "symbol": "WTC",
     "decimals": 18,
-    "name": "Waltonchain"
+    "name": "Waltonchain",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/wtc%402x.png"
   },
   {
     "address": "0xD717B75404022fb1C8582ADf1c66B9A553811754",
@@ -6115,22 +5963,19 @@
     "address": "0x1C83501478f1320977047008496DACBD60Bb15ef",
     "symbol": "DGTX",
     "decimals": 18,
-    "name": "DigitexFutures",
-    "logo": "https://digitexfutures.com/img/DGTX.png"
+    "name": "DigitexFutures"
   },
   {
     "address": "0x2a8E98e256f32259b5E5Cb55Dd63C8e891950666",
     "symbol": "PTC",
     "decimals": 18,
-    "name": "ParrotCoin",
-    "logo": "http://parrotcoin.club/favicon.ico"
+    "name": "ParrotCoin"
   },
   {
     "address": "0xdb0F69306FF8F949f258E83f6b87ee5D052d0b23",
     "symbol": "GCP",
     "decimals": 18,
-    "name": "Globcoin Crypto Platform",
-    "logo": "https://globcoin.io/assets/img/favicon-128x128.png"
+    "name": "Globcoin Crypto Platform"
   },
   {
     "address": "0x4a527d8fc13C5203AB24BA0944F4Cb14658D1Db6",
@@ -6172,8 +6017,7 @@
     "address": "0xb4d0FDFC8497AEF97d3c2892AE682eE06064A2BC",
     "symbol": "FMF",
     "decimals": 18,
-    "name": "Formosa Financial Token",
-    "logo": "https://avatars1.githubusercontent.com/u/40858534"
+    "name": "Formosa Financial Token"
   },
   {
     "address": "0x884e3902C4d5cFA86de4aCE7A96AA91EbC25C0Ff",
@@ -6191,8 +6035,7 @@
     "address": "0x0E8d6b471e332F140e7d9dbB99E5E3822F728DA6",
     "symbol": "ABYSS",
     "decimals": 18,
-    "name": "The Abyss",
-    "logo": "https://www.theabyss.com/static/img/abyss_28.png"
+    "name": "The Abyss"
   },
   {
     "address": "0x151202C9c18e495656f372281F493EB7698961D5",
@@ -6204,15 +6047,13 @@
     "address": "0x445f51299Ef3307dBD75036dd896565F5B4BF7A5",
     "symbol": "VIDT",
     "decimals": 18,
-    "name": "V-ID Token",
-    "logo": "https://www.v-id.org/_spheres_/custom-890/design/V-ID_icon_500x500.png"
+    "name": "V-ID Token"
   },
   {
     "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
     "symbol": "QNT",
     "decimals": 18,
-    "name": "Quant",
-    "logo": "https://developer.quant.network/quant-q-token_28x28.png"
+    "name": "Quant"
   },
   {
     "address": "0xfAE4Ee59CDd86e3Be9e8b90b53AA866327D7c090",
@@ -6230,14 +6071,14 @@
     "address": "0x660e71483785f66133548B10f6926dC332b06e61",
     "symbol": "ADL",
     "decimals": 18,
-    "name": "Adelphoi",
-    "logo": "https://pbs.twimg.com/profile_images/995709693044690944/5LSmUn49_400x400.png"
+    "name": "Adelphoi"
   },
   {
     "address": "0xB91318F35Bdb262E9423Bc7c7c2A3A93DD93C92C",
     "symbol": "NULS",
     "decimals": 18,
-    "name": "NULS"
+    "name": "NULS",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/nuls%402x.png"
   },
   {
     "address": "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413",
@@ -6255,14 +6096,14 @@
     "address": "0x82125AFe01819Dff1535D0D6276d57045291B6c0",
     "symbol": "MRL",
     "decimals": 18,
-    "name": "Marcelo",
-    "logo": "https://static.wixstatic.com/media/3e9a6a_15e519bd6672449182b4c3c557e49660~mv2.jpg/v1/fill/w_110,h_108,al_c,q_80,usm_0.66_1.00_0.01/3e9a6a_15e519bd6672449182b4c3c557e49660~mv2.webp"
+    "name": "Marcelo"
   },
   {
     "address": "0x38c6A68304cdEfb9BEc48BbFaABA5C5B47818bb2",
     "symbol": "HPB",
     "decimals": 18,
-    "name": "HPBCoin"
+    "name": "HPBCoin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/hpb%402x.png"
   },
   {
     "address": "0xB9bb08AB7E9Fa0A1356bd4A39eC0ca267E03b0b3",
@@ -6274,8 +6115,7 @@
     "address": "0xDF2C7238198Ad8B389666574f2d8bc411A4b7428",
     "symbol": "MFT",
     "decimals": 18,
-    "name": "Mainframe Token",
-    "logo": "https://raw.githubusercontent.com/MainframeHQ/branding/master/Illustrations/Mainframe_MFT_icon_120x120.png"
+    "name": "Mainframe Token"
   },
   {
     "address": "0x8A99ED8a1b204903Ee46e733f2c1286F6d20b177",
@@ -6287,8 +6127,7 @@
     "address": "0x4545750F39aF6Be4F237B6869D4EccA928Fd5A85",
     "symbol": "CTF",
     "decimals": 18,
-    "name": "CryptoTask",
-    "logo": "https://www.cryptotask.org/wp-content/uploads/2017/10/Logo_H-01.svg"
+    "name": "CryptoTask"
   },
   {
     "address": "0x1234567461d3f8Db7496581774Bd869C83D51c93",
@@ -6300,8 +6139,7 @@
     "address": "0x9FbA684D77D2d6A1408C24b60A1f5534e71f5b75",
     "symbol": "PATR",
     "decimals": 18,
-    "name": "PATRIOT",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1552326699/patriot-logo-28x28.png"
+    "name": "PATRIOT"
   },
   {
     "address": "0x922105fAd8153F516bCfB829f56DC097a0E1D705",
@@ -6332,7 +6170,7 @@
     "symbol": "BTM",
     "decimals": 8,
     "name": "Bytom",
-    "logo": "https://etherscan.io/token/images/bytom_28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/btm%402x.png"
   },
   {
     "address": "0x5136C98A80811C3f46bDda8B5c4555CFd9f812F0",
@@ -6344,8 +6182,7 @@
     "address": "0xE2E6D4BE086c6938B53B22144855eef674281639",
     "symbol": "LINK Platform",
     "decimals": 18,
-    "name": "Link Platform",
-    "logo": "https://etherscan.io/token/images/linkplatform28.png"
+    "name": "Link Platform"
   },
   {
     "address": "0xBDC5bAC39Dbe132B1E030e898aE3830017D7d969",
@@ -6357,8 +6194,7 @@
     "address": "0x1Ca43a170BaD619322e6f54d46b57e504dB663aA",
     "symbol": "AKC",
     "decimals": 18,
-    "name": "ARTWOOK COIN",
-    "logo": "https://artwook.com/logo/akc-line.png"
+    "name": "ARTWOOK COIN"
   },
   {
     "address": "0xEB9A4B185816C354dB92DB09cC3B50bE60b901b6",
@@ -6370,14 +6206,14 @@
     "address": "0xf9F7c29CFdf19FCf1f2AA6B84aA367Bcf1bD1676",
     "symbol": "DTT",
     "decimals": 18,
-    "name": "Delphi Tech Token",
-    "logo": "https://delphifund.org/wp-content/uploads/2018/04/delphi400x400.jpg"
+    "name": "Delphi Tech Token"
   },
   {
     "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
     "symbol": "POWR",
     "decimals": 6,
-    "name": "PowerLedger"
+    "name": "PowerLedger",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/powr%402x.png"
   },
   {
     "address": "0x2a093BcF0C98Ef744Bb6F69D74f2F85605324290",
@@ -6401,14 +6237,14 @@
     "address": "0xBeef546ac8a4e0a80DC1E2d696968Ef54138f1d4",
     "symbol": "OJX",
     "decimals": 18,
-    "name": "Ojooo Coin",
-    "logo": "https://ico.ojooo.com/images/token-logo.png"
+    "name": "Ojooo Coin"
   },
   {
     "address": "0xDD16eC0F66E54d453e6756713E533355989040E4",
     "symbol": "TEN",
     "decimals": 18,
-    "name": "Tokenomy"
+    "name": "Tokenomy",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ten%402x.png"
   },
   {
     "address": "0x58a4884182d9E835597f405e5F258290E46ae7C2",
@@ -6420,8 +6256,7 @@
     "address": "0x35BAA72038F127f9f8C8f9B491049f64f377914d",
     "symbol": "EPX",
     "decimals": 4,
-    "name": "ethPoker.io EPX",
-    "logo": "https://ethpoker.io/wp-content/uploads/2018/03/smallBlueIcon.png"
+    "name": "ethPoker.io EPX"
   },
   {
     "address": "0xBAb165dF9455AA0F2AeD1f2565520B91DDadB4c8",
@@ -6433,8 +6268,7 @@
     "address": "0x25B6325f5BB1c1E03cfbC3e53F470E1F1ca022E3",
     "symbol": "LML",
     "decimals": 18,
-    "name": "Lisk Machine Learning",
-    "logo": "https://public.liangnotes.com/images/gny/gny-logo.png"
+    "name": "Lisk Machine Learning"
   },
   {
     "address": "0x386467F1f3ddbE832448650418311a479EECFC57",
@@ -6447,7 +6281,7 @@
     "symbol": "AEUR",
     "decimals": 2,
     "name": "Augmint Euro",
-    "logo": "https://ipfs.io/ipfs/Qmdv6i9kgFke5mpTH5D2PfVyND1PAtva6p5WvTQUfgd6My"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/aeur%402x.png"
   },
   {
     "address": "0x106Aa49295B525fcf959aA75eC3f7dCbF5352f1C",
@@ -6471,7 +6305,8 @@
     "address": "0x96A65609a7B84E8842732DEB08f56C3E21aC6f8a",
     "symbol": "CTR",
     "decimals": 18,
-    "name": "Centra"
+    "name": "Centra",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ctr%402x.png"
   },
   {
     "address": "0x1122B6a0E00DCe0563082b6e2953f3A943855c1F",
@@ -6483,21 +6318,20 @@
     "address": "0x6B87999bE87358065bBdE41e8a0fe0B7b1cd2514",
     "symbol": "TSW",
     "decimals": 18,
-    "name": "TeslaWatt",
-    "logo": "https://www.teslawatt.com/icon-tesla1.jpg"
+    "name": "TeslaWatt"
   },
   {
     "address": "0xea5f88E54d982Cbb0c441cde4E79bC305e5b43Bc",
     "symbol": "PARETO",
     "decimals": 18,
-    "name": "PARETO",
-    "logo": "https://pareto.network/images/square500x500.png"
+    "name": "PARETO"
   },
   {
     "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
     "symbol": "BLZ",
     "decimals": 18,
-    "name": "Bluzelle"
+    "name": "Bluzelle",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/blz%402x.png"
   },
   {
     "address": "0xdb8646F5b487B5Dd979FAC618350e85018F557d4",
@@ -6509,15 +6343,13 @@
     "address": "0xD01DB73E047855Efb414e6202098C4Be4Cd2423B",
     "symbol": "UQC",
     "decimals": 18,
-    "name": "Uquid Coin",
-    "logo": "https://etherscan.io/token/images/uquid_28.png"
+    "name": "Uquid Coin"
   },
   {
     "address": "0x6BEB418Fc6E1958204aC8baddCf109B8E9694966",
     "symbol": "LNC (Linker Coin)",
     "decimals": 18,
-    "name": "Linker Coin",
-    "logo": "https://drive.google.com/file/d/1nvFvAFWTuMg5pH7W7Apoe_-Xob2-TY_u/view?usp=sharing"
+    "name": "Linker Coin"
   },
   {
     "address": "0xdA2C424Fc98c741c2d4ef2f42897CEfed897CA75",
@@ -6529,15 +6361,13 @@
     "address": "0x8e1b448EC7aDFc7Fa35FC2e885678bD323176E34",
     "symbol": "EGT",
     "decimals": 18,
-    "name": "Egretia Token",
-    "logo": "http://egretia.io/static/logo-356.png"
+    "name": "Egretia Token"
   },
   {
     "address": "0xF9D9702D031407F425a4412682fDc56b07d05262",
     "symbol": "WOC",
     "decimals": 0,
-    "name": "WallOfChain",
-    "logo": "https://wallofchain.com/assets/images/logo/icon_28x28px@2x.png"
+    "name": "WallOfChain"
   },
   {
     "address": "0x1EC8fE51a9B6A3a6C427D17d9ECC3060fbc4a45c",
@@ -6567,8 +6397,7 @@
     "address": "0xA024E8057EEC474a9b2356833707Dd0579E26eF3",
     "symbol": "$FXY",
     "decimals": 18,
-    "name": "$FIXY NETWORK",
-    "logo": "https://ibb.co/diUwiJ"
+    "name": "$FIXY NETWORK"
   },
   {
     "address": "0x621d78f2EF2fd937BFca696CabaF9A779F59B3Ed",
@@ -6580,8 +6409,7 @@
     "address": "0x2799D90C6d44Cb9Aa5fBC377177F16C33E056b82",
     "symbol": "DRP (Dripcoin)",
     "decimals": 0,
-    "name": "Dripcoin",
-    "logo": "https://i.imgur.com/3V7N7hr.png"
+    "name": "Dripcoin"
   },
   {
     "address": "0x78a73B6CBc5D183CE56e786f6e905CaDEC63547B",
@@ -6593,19 +6421,22 @@
     "address": "0xE5Dada80Aa6477e85d09747f2842f7993D0Df71C",
     "symbol": "DOCK",
     "decimals": 18,
-    "name": "Dock"
+    "name": "Dock",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dock%402x.png"
   },
   {
     "address": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
     "symbol": "MTL",
     "decimals": 8,
-    "name": "Metal"
+    "name": "Metal",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mtl%402x.png"
   },
   {
     "address": "0xd234BF2410a0009dF9c3C63b610c09738f18ccD7",
     "symbol": "DTR",
     "decimals": 8,
-    "name": "Dynamic Trading Rights"
+    "name": "Dynamic Trading Rights",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dtr%402x.png"
   },
   {
     "address": "0x7e667525521cF61352e2E01b50FaaaE7Df39749a",
@@ -6617,8 +6448,7 @@
     "address": "0x88aC94D5d175130347Fc95E109d77AC09dbF5ab7",
     "symbol": "HKY",
     "decimals": 18,
-    "name": "Hicky",
-    "logo": "http://hicky.io/assets/img/hicky-icon.svg"
+    "name": "Hicky"
   },
   {
     "address": "0x44bf22949F9cc84b61B9328a9d885d1b5C806b41",
@@ -6630,8 +6460,7 @@
     "address": "0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf",
     "symbol": "GEN",
     "decimals": 18,
-    "name": "DAOstack",
-    "logo": "https://daostack.io/daostack2828.png"
+    "name": "DAOstack"
   },
   {
     "address": "0x9720b467a710382A232a32F540bDCed7d662a10B",
@@ -6649,21 +6478,20 @@
     "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
     "symbol": "TUSD",
     "decimals": 18,
-    "name": "TrueUSD"
+    "name": "TrueUSD",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/tusd%402x.png"
   },
   {
     "address": "0x4DF47B4969B2911C966506E3592c41389493953b",
     "symbol": "FND",
     "decimals": 18,
-    "name": "FundRequest",
-    "logo": "https://raw.githubusercontent.com/FundRequest/logo/master/Logo%20icon%20500x500.png"
+    "name": "FundRequest"
   },
   {
     "address": "0xb0D926c1BC3d78064F3e1075D5bD9A24F35Ae6C5",
     "symbol": "ARXT",
     "decimals": 18,
-    "name": "Assistive Reality ARX",
-    "logo": "https://aronline.io/wp-content/uploads/2018/01/favicon.png"
+    "name": "Assistive Reality ARX"
   },
   {
     "address": "0x054C64741dBafDC19784505494029823D89c3b13",
@@ -6687,8 +6515,7 @@
     "address": "0xCa3c18a65b802eC267f8f4802545e7F53D24C75e",
     "symbol": "BUC",
     "decimals": 18,
-    "name": "BeeUnity Chain",
-    "logo": "http://beeunity.org/wp-content/uploads/2018/03/buc60.png"
+    "name": "BeeUnity Chain"
   },
   {
     "address": "0x0ABeFb7611Cb3A01EA3FaD85f33C3C934F8e2cF4",
@@ -6712,7 +6539,8 @@
     "address": "0x667088b212ce3d06a1b553a7221E1fD19000d9aF",
     "symbol": "WINGS",
     "decimals": 18,
-    "name": "WINGS"
+    "name": "WINGS",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/wings%402x.png"
   },
   {
     "address": "0x2008e3057BD734e10AD13c9EAe45Ff132aBc1722",
@@ -6736,13 +6564,15 @@
     "address": "0x39Bb259F66E1C59d5ABEF88375979b4D20D98022",
     "symbol": "WAX",
     "decimals": 8,
-    "name": "WAX"
+    "name": "WAX",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/wax%402x.png"
   },
   {
     "address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
     "symbol": "FUN",
     "decimals": 8,
-    "name": "Funfair"
+    "name": "Funfair",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/fun%402x.png"
   },
   {
     "address": "0x422866a8F0b032c5cf1DfBDEf31A20F4509562b0",
@@ -6754,7 +6584,8 @@
     "address": "0x8f3470A7388c05eE4e7AF3d01D8C722b0FF52374",
     "symbol": "VERI",
     "decimals": 18,
-    "name": "Veritaseum"
+    "name": "Veritaseum",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/veri%402x.png"
   },
   {
     "address": "0x24A77c1F17C547105E14813e517be06b0040aa76",
@@ -6766,7 +6597,8 @@
     "address": "0x983F6d60db79ea8cA4eB9968C6aFf8cfA04B3c63",
     "symbol": "SNM",
     "decimals": 18,
-    "name": "SONM"
+    "name": "SONM",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/snm%402x.png"
   },
   {
     "address": "0x1063ce524265d5a3A624f4914acd573dD89ce988",
@@ -6778,14 +6610,14 @@
     "address": "0x960b236A07cf122663c4303350609A66A7B288C0",
     "symbol": "ANT",
     "decimals": 18,
-    "name": "Aragon"
+    "name": "Aragon",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ant%402x.png"
   },
   {
     "address": "0x6aEB95F06CDA84cA345c2dE0F3B7f96923a44f4c",
     "symbol": "BERRY",
     "decimals": 14,
-    "name": "Berry",
-    "logo": "https://etherscan.io/token/images/rentberry_28.png"
+    "name": "Berry"
   },
   {
     "address": "0xb62d18DeA74045E822352CE4B3EE77319DC5ff2F",
@@ -6827,8 +6659,7 @@
     "address": "0x8C65e992297d5f092A756dEf24F4781a280198Ff",
     "symbol": "GZE",
     "decimals": 18,
-    "name": "GazeCoin",
-    "logo": "https://media.gazecoin.io/static/icons/gazecoin-28x28-on-trans.png"
+    "name": "GazeCoin"
   },
   {
     "address": "0x36905Fc93280f52362A1CBAB151F25DC46742Fb5",
@@ -6840,7 +6671,8 @@
     "address": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A",
     "symbol": "DGD",
     "decimals": 9,
-    "name": "Digix DAO"
+    "name": "Digix DAO",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dgd%402x.png"
   },
   {
     "address": "0x49b127Bc33ce7E1586EC28CEC6a65b112596C822",
@@ -6882,8 +6714,7 @@
     "address": "0x28dee01D53FED0Edf5f6E310BF8Ef9311513Ae40",
     "symbol": "XBP",
     "decimals": 18,
-    "name": "BlitzPredict",
-    "logo": "https://s3.amazonaws.com/blitzpredict-public/MEW+Logo.png"
+    "name": "BlitzPredict"
   },
   {
     "address": "0xaEc98A708810414878c3BCDF46Aad31dEd4a4557",
@@ -6895,8 +6726,7 @@
     "address": "0x9344b383b1D59b5ce3468B234DAB43C7190ba735",
     "symbol": "NCC (NeedsCoin)",
     "decimals": 18,
-    "name": "NeedsCoin",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1542398850/NeedsCoinLogo/ncc.png"
+    "name": "NeedsCoin"
   },
   {
     "address": "0x5d48F293BaED247A2D0189058bA37aa238bD4725",
@@ -6920,14 +6750,14 @@
     "address": "0xA9877b1e05D035899131DBd1e403825166D09f92",
     "symbol": "MNT",
     "decimals": 18,
-    "name": "Media Network Token",
-    "logo": "https://etherscan.io/token/images/coinjoker_28.png"
+    "name": "Media Network Token"
   },
   {
     "address": "0x3833ddA0AEB6947b98cE454d89366cBA8Cc55528",
     "symbol": "SPHTX",
     "decimals": 18,
-    "name": "SPHTX"
+    "name": "SPHTX",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/sphtx%402x.png"
   },
   {
     "address": "0xD65960FAcb8E4a2dFcb2C2212cb2e44a02e2a57E",
@@ -6945,7 +6775,8 @@
     "address": "0x12fCd6463E66974cF7bBC24FFC4d40d6bE458283",
     "symbol": "GBX",
     "decimals": 18,
-    "name": "Globitex"
+    "name": "Globitex",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gbx%402x.png"
   },
   {
     "address": "0x95dAaaB98046846bF4B2853e23cba236fa394A31",
@@ -6957,8 +6788,7 @@
     "address": "0xA517a46Baad6B054A76bD19c46844f717fe69fea",
     "symbol": "CARB",
     "decimals": 8,
-    "name": "CarbCoin",
-    "logo": "https://carbcoin.eu/logo.jpg"
+    "name": "CarbCoin"
   },
   {
     "address": "0xa7f976C360ebBeD4465c2855684D1AAE5271eFa9",
@@ -6970,7 +6800,8 @@
     "address": "0x5B2e4a700dfBc560061e957edec8F6EeEb74a320",
     "symbol": "INS",
     "decimals": 10,
-    "name": "Insolar"
+    "name": "Insolar",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ins%402x.png"
   },
   {
     "address": "0x523630976eB6147621B5c31c781eBe2Ec2a806E0",
@@ -6988,7 +6819,8 @@
     "address": "0x1c4481750daa5Ff521A2a7490d9981eD46465Dbd",
     "symbol": "BCPT",
     "decimals": 18,
-    "name": "BlockMason Credit Protocol Token"
+    "name": "BlockMason Credit Protocol Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bcpt%402x.png"
   },
   {
     "address": "0x554C20B7c486beeE439277b4540A434566dC4C02",
@@ -7024,8 +6856,7 @@
     "address": "0x24692791Bc444c5Cd0b81e3CBCaba4b04Acd1F3B",
     "symbol": "UKG",
     "decimals": 18,
-    "name": "UnikoinGold",
-    "logo": "https://f.unkrn.com/2017-11-04/a/1509813079_unikoin-icon-gold.svg"
+    "name": "UnikoinGold"
   },
   {
     "address": "0x846C66cf71C43f80403B51fE3906B3599D63336f",
@@ -7043,7 +6874,8 @@
     "address": "0xC5bBaE50781Be1669306b9e001EFF57a2957b09d",
     "symbol": "GTO",
     "decimals": 5,
-    "name": "Gifto"
+    "name": "Gifto",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gto%402x.png"
   },
   {
     "address": "0x8810C63470d38639954c6B41AaC545848C46484a",
@@ -7055,22 +6887,19 @@
     "address": "0x7297862B9670fF015192799cc849726c88bf1d77",
     "symbol": "SKYM",
     "decimals": 18,
-    "name": "Skymap Token",
-    "logo": "https://www.soar.earth/img/soar_logo_black.png"
+    "name": "Skymap Token"
   },
   {
     "address": "0x047187e53477be70DBe8Ea5B799318f2e165052F",
     "symbol": "OMT",
     "decimals": 18,
-    "name": "OTCMAKER Token",
-    "logo": "https://storage.googleapis.com/static.otcmaker.com/CoinLogo-OMT%202.png"
+    "name": "OTCMAKER Token"
   },
   {
     "address": "0x92685E93956537c25Bb75D5d47fca4266dd628B8",
     "symbol": "BTL (Bitlle)",
     "decimals": 4,
-    "name": "Bitlle Token",
-    "logo": "https://bitlle.com/img/btl.png"
+    "name": "Bitlle Token"
   },
   {
     "address": "0x50Ee674689d75C0f88E8f83cfE8c4B69E8fd590D",
@@ -7082,34 +6911,34 @@
     "address": "0x2eb86e8fC520E0F6Bb5D9Af08F924fe70558Ab89",
     "symbol": "LGR",
     "decimals": 8,
-    "name": "Logarithm",
-    "logo": "https://getlogarithm.com/images/logo256.png"
+    "name": "Logarithm"
   },
   {
     "address": "0x286BDA1413a2Df81731D4930ce2F862a35A609fE",
     "symbol": "WABI",
     "decimals": 18,
     "name": "Tael",
-    "logo": "https://etherscan.io/token/images/wacoin_28.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/wabi%402x.png"
   },
   {
     "address": "0x14C926F2290044B647e1Bf2072e67B495eff1905",
     "symbol": "BETHER",
     "decimals": 18,
-    "name": "Bethereum",
-    "logo": "https://image.ibb.co/jPRLCx/icon_default_1.png"
+    "name": "Bethereum"
   },
   {
     "address": "0x68d57c9a1C35f63E2c83eE8e49A64e9d70528D25",
     "symbol": "SRN",
     "decimals": 18,
-    "name": "Sirin Labs"
+    "name": "Sirin Labs",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/srn%402x.png"
   },
   {
     "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
     "symbol": "KNC",
     "decimals": 18,
-    "name": "Kyber Network"
+    "name": "Kyber Network",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/knc%402x.png"
   },
   {
     "address": "0xc12d099be31567add4e4e4d0D45691C3F58f5663",
@@ -7133,14 +6962,14 @@
     "address": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
     "symbol": "PAY",
     "decimals": 18,
-    "name": "TenX"
+    "name": "TenX",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/pay%402x.png"
   },
   {
     "address": "0xe8A1Df958bE379045E2B46a31A98B93A2eCDfDeD",
     "symbol": "ESZ",
     "decimals": 18,
-    "name": "ESZCoin",
-    "logo": "https://ethersportz.com/ESZCoin200by200.png"
+    "name": "ESZCoin"
   },
   {
     "address": "0xa44E5137293E855B1b7bC7E2C6f8cD796fFCB037",
@@ -7158,7 +6987,8 @@
     "address": "0xaeC2E87E0A235266D9C5ADc9DEb4b2E29b54D009",
     "symbol": "SNGLS",
     "decimals": 0,
-    "name": "SingularDTV"
+    "name": "SingularDTV",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/sngls%402x.png"
   },
   {
     "address": "0x4A89cD486fA996ad50c0a63C35c78702f5422a50",
@@ -7170,7 +7000,8 @@
     "address": "0x72dD4b6bd852A3AA172Be4d6C5a6dbEc588cf131",
     "symbol": "NGC",
     "decimals": 18,
-    "name": "NAGA Coin"
+    "name": "NAGA Coin",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ngc%402x.png"
   },
   {
     "address": "0x887834D3b8D450B6bAB109c252Df3DA286d73CE4",
@@ -7182,8 +7013,7 @@
     "address": "0x0C91B015AbA6f7B4738dcD36E7410138b29ADC29",
     "symbol": "COIL",
     "decimals": 8,
-    "name": "CoinOil",
-    "logo": "https://coinoil.io/oldw/assets/images/logo/icon.png"
+    "name": "CoinOil"
   },
   {
     "address": "0xBB1fA4FdEB3459733bF67EbC6f893003fA976a82",
@@ -7195,8 +7025,7 @@
     "address": "0xf49CDD50aD408d387d611F88A647179C3de3492b",
     "symbol": "CRGO",
     "decimals": 18,
-    "name": "CargoCoin",
-    "logo": "https://thecargocoin.com/images/logo_icon.png"
+    "name": "CargoCoin"
   },
   {
     "address": "0x025abAD9e518516fdaAFBDcdB9701b37fb7eF0FA",
@@ -7214,7 +7043,8 @@
     "address": "0x103c3A209da59d3E7C4A89307e66521e081CFDF0",
     "symbol": "GVT",
     "decimals": 18,
-    "name": "Genesis Vision"
+    "name": "Genesis Vision",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gvt%402x.png"
   },
   {
     "address": "0x4946583c5b86E01cCD30c71a05617D06E3E73060",
@@ -7226,7 +7056,8 @@
     "address": "0xc8C6A31A4A806d3710A7B38b7B296D2fABCCDBA8",
     "symbol": "ELIX",
     "decimals": 18,
-    "name": "Elixir Token"
+    "name": "Elixir Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/elix%402x.png"
   },
   {
     "address": "0xAd8DD4c725dE1D31b9E8F8D146089e9DC6882093",
@@ -7280,8 +7111,7 @@
     "address": "0xd82Df0ABD3f51425Eb15ef7580fDA55727875f14",
     "symbol": "DAV",
     "decimals": 18,
-    "name": "DAV Token",
-    "logo": "https://dav.network/img/logo-mew.png"
+    "name": "DAV Token"
   },
   {
     "address": "0x0d88eD6E74bbFD96B831231638b66C05571e824F",
@@ -7299,15 +7129,13 @@
     "address": "0xFA1DE2Ee97e4c10C94C91Cb2b5062b89Fb140b82",
     "symbol": "EDC",
     "decimals": 6,
-    "name": "Education Credits",
-    "logo": "https://edc.network/images/edc-logo28.png"
+    "name": "Education Credits"
   },
   {
     "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
     "symbol": "REN",
     "decimals": 18,
-    "name": "Republic Token",
-    "logo": "https://republicprotocol.github.io/files/logo/128x128.png"
+    "name": "Republic Token"
   },
   {
     "address": "0x2ccbFF3A042c68716Ed2a2Cb0c544A9f1d1935E1",
@@ -7337,8 +7165,7 @@
     "address": "0x8F936fE0faF0604c9C0Ef2406bde0A65365515d6",
     "symbol": "WCN",
     "decimals": 18,
-    "name": "WorldCoinNetwork",
-    "logo": "https://i.imgur.com/I4Rzoad.png "
+    "name": "WorldCoinNetwork"
   },
   {
     "address": "0xb444208cB0516C150178fCf9a52604BC04A1aCEa",
@@ -7350,8 +7177,7 @@
     "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
     "symbol": "OGN",
     "decimals": 18,
-    "name": "OriginToken",
-    "logo": "https://www.originprotocol.com/static/img/origin-icon-128x128.png"
+    "name": "OriginToken"
   },
   {
     "address": "0x83eEA00D838f92dEC4D1475697B9f4D3537b56E3",
@@ -7369,28 +7195,27 @@
     "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
     "symbol": "BNT",
     "decimals": 18,
-    "name": "Bancor"
+    "name": "Bancor",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/bnt%402x.png"
   },
   {
     "address": "0x9f6513ED2b0DE89218E97DB4A5115ba04Be449f1",
     "symbol": "WAK",
     "decimals": 18,
-    "name": "Wak Coin",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1549991462/wak-logo-28x28.png"
+    "name": "Wak Coin"
   },
   {
     "address": "0x080aa07E2C7185150d7e4DA98838A8d2feac3dfC",
     "symbol": "BTT",
     "decimals": 0,
     "name": "Bitether",
-    "logo": "https://www.bitether.co/wp-content/uploads/thegem-logos/logo_865d0b770c80162beeec3624ca062e6d_1x.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/btt%402x.png"
   },
   {
     "address": "0x5D858bcd53E085920620549214a8b27CE2f04670",
     "symbol": "POP",
     "decimals": 18,
-    "name": "POP Network Token",
-    "logo": "https://i.imgur.com/KEVDyw4.png"
+    "name": "POP Network Token"
   },
   {
     "address": "0x687174f8C49ceb7729D925C3A961507ea4Ac7b28",
@@ -7402,7 +7227,8 @@
     "address": "0xa74476443119A942dE498590Fe1f2454d7D4aC0d",
     "symbol": "GNT",
     "decimals": 18,
-    "name": "Golem"
+    "name": "Golem",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gnt%402x.png"
   },
   {
     "address": "0x3839d8ba312751Aa0248fEd6a8bACB84308E20Ed",
@@ -7420,8 +7246,7 @@
     "address": "0x8D5682941cE456900b12d47ac06a88b47C764CE1",
     "symbol": "RMESH",
     "decimals": 18,
-    "name": "RightMesh Token",
-    "logo": "https://avatars2.githubusercontent.com/u/29805586?s=128"
+    "name": "RightMesh Token"
   },
   {
     "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
@@ -7439,29 +7264,25 @@
     "address": "0x96c30D5499EF6eA96A9c221Bc18BC39D29c97F27",
     "symbol": "Thar",
     "decimals": 18,
-    "name": "Thar token",
-    "logo": "https://res.cloudinary.com/cloudimgstorage/image/upload/v1553154858/Thar-Logo-128x128.png"
+    "name": "Thar token"
   },
   {
     "address": "0x84936cF7630AA3e27Dd9AfF968b140d5AEE49F5a",
     "symbol": "AMTC",
     "decimals": 8,
-    "name": "AmberTime Coin",
-    "logo": "https://ambertime.org/img/amber-logo-white.png"
+    "name": "AmberTime Coin"
   },
   {
     "address": "0x554FFc77F4251a9fB3c0E3590a6a205f8d4e067D",
     "symbol": "ZMN",
     "decimals": 18,
-    "name": "ZMINE",
-    "logo": "https://zmine.com/img/logo_300x300.png"
+    "name": "ZMINE"
   },
   {
     "address": "0xdd007278B667F6bef52fD0a4c23604aA1f96039a",
     "symbol": "RIPT",
     "decimals": 8,
-    "name": "RiptideCoin",
-    "logo": "https://etherscan.io/token/images/riptide_28.png"
+    "name": "RiptideCoin"
   },
   {
     "address": "0x8E5610ab5E39d26828167640EA29823fe1dD5843",
@@ -7485,7 +7306,8 @@
     "address": "0x7C5A0CE9267ED19B22F8cae653F198e3E8daf098",
     "symbol": "SAN",
     "decimals": 18,
-    "name": "Santiment"
+    "name": "Santiment",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/san%402x.png"
   },
   {
     "address": "0x82fdedfB7635441aA5A92791D001fA7388da8025",
@@ -7509,28 +7331,26 @@
     "address": "0x20E94867794dBA030Ee287F1406E100d03C84Cd3",
     "symbol": "DEW",
     "decimals": 18,
-    "name": "DEW"
+    "name": "DEW",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dew%402x.png"
   },
   {
     "address": "0x247551F2EB3362E222c742E9c788B8957D9BC87e",
     "symbol": "GNY",
     "decimals": 18,
-    "name": "GNY",
-    "logo": "https://public.liangnotes.com/images/gny/gny-logo.png"
+    "name": "GNY"
   },
   {
     "address": "0x47e67BA66b0699500f18A53F94E2b9dB3D47437e",
     "symbol": "PXG",
     "decimals": 18,
-    "name": "PlayGame",
-    "logo": "https://its.playgame.com/images/logo-white.png"
+    "name": "PlayGame"
   },
   {
     "address": "0xEfbB3F1058fd8E0C9d7204f532E17d7572AFfc3e",
     "symbol": "MBCASH",
     "decimals": 18,
-    "name": "MBCash",
-    "logo": "https://mbcash.me/mbcash.png"
+    "name": "MBCash"
   },
   {
     "address": "0xe25ff6Eb959BCE67975778e46A47750C243B6B99",
@@ -7542,14 +7362,14 @@
     "address": "0x45e42D659D9f9466cD5DF622506033145a9b89Bc",
     "symbol": "NxC",
     "decimals": 3,
-    "name": "Nexium",
-    "logo": "https://www.beyond-the-void.net/nxc.png"
+    "name": "Nexium"
   },
   {
     "address": "0x4156D3342D5c385a87D264F90653733592000581",
     "symbol": "SALT",
     "decimals": 8,
-    "name": "Salt Lending Token"
+    "name": "Salt Lending Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/salt%402x.png"
   },
   {
     "address": "0x4289c043A12392F1027307fB58272D8EBd853912",
@@ -7573,15 +7393,13 @@
     "address": "0xdd94De9cFE063577051A5eb7465D08317d8808B6",
     "symbol": "Devcon2 Token",
     "decimals": 0,
-    "name": "Devcon2 Token",
-    "logo": "https://etherscan.io/token/images/Devcon2.png"
+    "name": "Devcon2 Token"
   },
   {
     "address": "0xab95E915c123fdEd5BDfB6325e35ef5515F1EA69",
     "symbol": "XNN",
     "decimals": 18,
-    "name": "XENON",
-    "logo": "https://etherscan.io/token/images/xenon_28.png"
+    "name": "XENON"
   },
   {
     "address": "0x671AbBe5CE652491985342e85428EB1b07bC6c64",
@@ -7593,8 +7411,7 @@
     "address": "0x7F585B9130c64e9e9F470b618A7badD03D79cA7E",
     "symbol": "CR7",
     "decimals": 18,
-    "name": "CR7Coin",
-    "logo": "https://cr7coin.org/assets/images/128.png"
+    "name": "CR7Coin"
   },
   {
     "address": "0x33f90Dee07c6E8B9682dD20F73E6C358B2ED0f03",
@@ -7619,7 +7436,7 @@
     "symbol": "DRGN",
     "decimals": 18,
     "name": "Dragon",
-    "logo": "https://dragonchain.com/assets/images/dragon.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/drgn%402x.png"
   },
   {
     "address": "0xE2FB6529EF566a080e6d23dE0bd351311087D567",
@@ -7631,7 +7448,8 @@
     "address": "0x5CA9a71B1d01849C0a95490Cc00559717fCF0D1d",
     "symbol": "AE",
     "decimals": 18,
-    "name": "aeternity"
+    "name": "aeternity",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/ae%402x.png"
   },
   {
     "address": "0x773450335eD4ec3DB45aF74f34F2c85348645D39",
@@ -7673,8 +7491,7 @@
     "address": "0xa02e3bB9cEbc03952601B3724B4940e0845BeBcf",
     "symbol": "BTHR",
     "decimals": 18,
-    "name": "Bethereum",
-    "logo": "https://image.ibb.co/jPRLCx/icon_default_1.png"
+    "name": "Bethereum"
   },
   {
     "address": "0x859a9C0b44cb7066D956a958B0b82e54C9e44b4B",
@@ -7734,7 +7551,8 @@
     "address": "0x228ba514309FFDF03A81a205a6D040E429d6E80C",
     "symbol": "GSC",
     "decimals": 18,
-    "name": "Global Social Chain"
+    "name": "Global Social Chain",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gsc%402x.png"
   },
   {
     "address": "0xE69a353b3152Dd7b706ff7dD40fe1d18b7802d31",
@@ -7747,7 +7565,7 @@
     "symbol": "STQ",
     "decimals": 18,
     "name": "Storiqa",
-    "logo": "https://s2.coinmarketcap.com/static/img/coins/32x32/2541.png"
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/stq%402x.png"
   },
   {
     "address": "0x3618516F45CD3c913F81F9987AF41077932Bc40d",
@@ -7765,8 +7583,7 @@
     "address": "0x38c87AA89B2B8cD9B95b736e1Fa7b612EA972169",
     "symbol": "AMO",
     "decimals": 18,
-    "name": "AMO Coin",
-    "logo": "https://amo.foundation/wordpress/wp-content/uploads/2018/05/symbol.png"
+    "name": "AMO Coin"
   },
   {
     "address": "0xf278c1CA969095ffddDED020290cf8B5C424AcE2",

--- a/packages/fether-react/src/assets/tokens/goerli.json
+++ b/packages/fether-react/src/assets/tokens/goerli.json
@@ -1,0 +1,8 @@
+[
+  {
+    "address": "0x7af963cF6D228E564e2A0aA0DdBF06210B38615D",
+    "symbol": "TST",
+    "decimals": 18,
+    "name": "goerli Test token"
+  }
+]

--- a/packages/fether-react/src/assets/tokens/kovan.json
+++ b/packages/fether-react/src/assets/tokens/kovan.json
@@ -1,5 +1,6 @@
 [
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mkr%402x.png",
     "address": "0x1Dad4783cf3fe3085C1426157aB175A6119A04bA",
     "symbol": "MKR",
     "decimals": 18,
@@ -13,18 +14,21 @@
     "logo": "https://i.imgur.com/qvmnsxw.jpg"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dai%402x.png",
     "address": "0xC4375B7De8af5a38a93548eb8453a498222C4fF2",
     "symbol": "DAI",
     "decimals": 18,
     "name": "RadarRelay test Dai Stablecoin v1.0"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gnt%402x.png",
     "address": "0xeF7FfF64389B814A946f3E92105513705CA6B990",
     "symbol": "GNT",
     "decimals": 18,
     "name": "RadarRelay test Golem Network Token"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rep%402x.png",
     "address": "0xB18845c260F680d5B9D84649638813E342E4F8C9",
     "symbol": "REP",
     "decimals": 18,
@@ -37,19 +41,21 @@
     "name": "Aeternity"
   },
   {
+    "logo": "https://ipfs.io/ipfs/QmcjNqEC4uDyZJBM946Pyrh8murWVkMh9ufBjpt5hPYuZp",
     "address": "0xc57538846Ec405Ea25Deb00e0f9B29a432D53507",
     "symbol": "RLC",
     "decimals": 9,
-    "name": "iExec RLC",
-    "logo": "https://ipfs.io/ipfs/QmcjNqEC4uDyZJBM946Pyrh8murWVkMh9ufBjpt5hPYuZp"
+    "name": "iExec RLC"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dgd%402x.png",
     "address": "0xeeE3870657E4716670f185dF08652dd848fe8f7e",
     "symbol": "DGD",
     "decimals": 18,
     "name": "RadarRelay test Digix DAO Token"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gup%402x.png",
     "address": "0x3C67f7D4decF7795225f51b54134F81137385f83",
     "symbol": "GUP",
     "decimals": 3,
@@ -63,12 +69,14 @@
     "logo": "https://raw.githubusercontent.com/ethcore/dapp-assets/9e135f76fe9ba61e2d8ccbd72ed144c26c450780/tokens/gavcoin-64x64.png"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mln%402x.png",
     "address": "0x323B5d4C32345ced77393B3530b1EeD0f346429D",
     "symbol": "MLN",
     "decimals": 18,
     "name": "RadarRelay test Melon Tokens"
   },
   {
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/zrx%402x.png",
     "address": "0x6Ff6C0Ff1d68b964901F986d4C9FA3ac68346570",
     "symbol": "ZRX",
     "decimals": 18,

--- a/packages/fether-react/src/assets/tokens/kovan.json
+++ b/packages/fether-react/src/assets/tokens/kovan.json
@@ -1,38 +1,37 @@
 [
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mkr%402x.png",
     "address": "0x1Dad4783cf3fe3085C1426157aB175A6119A04bA",
     "symbol": "MKR",
     "decimals": 18,
-    "name": "RadarRelay test MakerDAO"
+    "name": "RadarRelay test MakerDAO",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mkr%402x.png"
   },
   {
     "address": "0x4A6e6C3868A279e1D9047B42C3fB356FF4680003",
     "symbol": "TIB",
     "decimals": 18,
-    "name": "ThibCoin",
-    "logo": "https://i.imgur.com/qvmnsxw.jpg"
+    "name": "ThibCoin"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dai%402x.png",
     "address": "0xC4375B7De8af5a38a93548eb8453a498222C4fF2",
     "symbol": "DAI",
     "decimals": 18,
-    "name": "RadarRelay test Dai Stablecoin v1.0"
+    "name": "RadarRelay test Dai Stablecoin v1.0",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dai%402x.png"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gnt%402x.png",
     "address": "0xeF7FfF64389B814A946f3E92105513705CA6B990",
     "symbol": "GNT",
     "decimals": 18,
-    "name": "RadarRelay test Golem Network Token"
+    "name": "RadarRelay test Golem Network Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gnt%402x.png"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rep%402x.png",
     "address": "0xB18845c260F680d5B9D84649638813E342E4F8C9",
     "symbol": "REP",
     "decimals": 18,
-    "name": "RadarRelay test Augur Reputation Token"
+    "name": "RadarRelay test Augur Reputation Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rep%402x.png"
   },
   {
     "address": "0x8667559254241ddeD4d11392f868d72092765367",
@@ -41,45 +40,44 @@
     "name": "Aeternity"
   },
   {
-    "logo": "https://ipfs.io/ipfs/QmcjNqEC4uDyZJBM946Pyrh8murWVkMh9ufBjpt5hPYuZp",
     "address": "0xc57538846Ec405Ea25Deb00e0f9B29a432D53507",
     "symbol": "RLC",
     "decimals": 9,
-    "name": "iExec RLC"
+    "name": "iExec RLC",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rlc%402x.png"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dgd%402x.png",
     "address": "0xeeE3870657E4716670f185dF08652dd848fe8f7e",
     "symbol": "DGD",
     "decimals": 18,
-    "name": "RadarRelay test Digix DAO Token"
+    "name": "RadarRelay test Digix DAO Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/dgd%402x.png"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gup%402x.png",
     "address": "0x3C67f7D4decF7795225f51b54134F81137385f83",
     "symbol": "GUP",
     "decimals": 3,
-    "name": "GUP"
+    "name": "GUP",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/gup%402x.png"
   },
   {
     "address": "0x4733659a5cB7896A65c918Add6f59C5148FB5ffa",
     "symbol": "GAV",
     "decimals": 6,
-    "name": "GavCoin",
-    "logo": "https://raw.githubusercontent.com/ethcore/dapp-assets/9e135f76fe9ba61e2d8ccbd72ed144c26c450780/tokens/gavcoin-64x64.png"
+    "name": "GavCoin"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mln%402x.png",
     "address": "0x323B5d4C32345ced77393B3530b1EeD0f346429D",
     "symbol": "MLN",
     "decimals": 18,
-    "name": "RadarRelay test Melon Tokens"
+    "name": "RadarRelay test Melon Tokens",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/mln%402x.png"
   },
   {
-    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/zrx%402x.png",
     "address": "0x6Ff6C0Ff1d68b964901F986d4C9FA3ac68346570",
     "symbol": "ZRX",
     "decimals": 18,
-    "name": "RadarRelay test 0x Protocol Token"
+    "name": "RadarRelay test 0x Protocol Token",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/zrx%402x.png"
   }
 ]

--- a/packages/fether-react/src/assets/tokens/ropsten.json
+++ b/packages/fether-react/src/assets/tokens/ropsten.json
@@ -1,17 +1,16 @@
 [
   {
-    "logo": "https://ipfs.io/ipfs/QmcjNqEC4uDyZJBM946Pyrh8murWVkMh9ufBjpt5hPYuZp",
     "address": "0x7314Dc4d7794b5E7894212CA1556ae8e3De58621",
     "symbol": "RLC",
     "decimals": 9,
-    "name": "iExec RLC"
+    "name": "iExec RLC",
+    "logo": "https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/rlc%402x.png"
   },
   {
     "address": "0x6f95a3B682F8e9aacC86D057A6DF88A0E68145A8",
     "symbol": "ILSC",
     "decimals": 2,
-    "name": "IsraCoin",
-    "logo": "https://i.imgur.com/I1qkFfm.png"
+    "name": "IsraCoin"
   },
   {
     "address": "0xa1bAccA0e12D4091Ec1f92e7CaE3394CC9854D3D",

--- a/packages/fether-react/src/assets/tokens/ropsten.json
+++ b/packages/fether-react/src/assets/tokens/ropsten.json
@@ -1,10 +1,10 @@
 [
   {
+    "logo": "https://ipfs.io/ipfs/QmcjNqEC4uDyZJBM946Pyrh8murWVkMh9ufBjpt5hPYuZp",
     "address": "0x7314Dc4d7794b5E7894212CA1556ae8e3De58621",
     "symbol": "RLC",
     "decimals": 9,
-    "name": "iExec RLC",
-    "logo": "https://ipfs.io/ipfs/QmcjNqEC4uDyZJBM946Pyrh8murWVkMh9ufBjpt5hPYuZp"
+    "name": "iExec RLC"
   },
   {
     "address": "0x6f95a3B682F8e9aacC86D057A6DF88A0E68145A8",

--- a/packages/fether-ui/src/TokenCard/TokenCard.js
+++ b/packages/fether-ui/src/TokenCard/TokenCard.js
@@ -21,17 +21,18 @@ export const TokenCard = ({
   <Card {...otherProps}>
     <div className='token'>
       <div className='token_icon'>
-        <img
-          alt={token.symbol}
-          src={
-            (!!token.logo && token.logo) ||
-            `https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/${token.symbol.toLowerCase()}%402x.png`
-          }
-          onError={ev => {
-            ev.target.onerror = null;
-            ev.target.src = defaultTokenImage;
-          }}
-        />
+        {!!token && !!token.logo ? (
+          <img
+            alt={token.symbol}
+            src={token.logo}
+            onError={ev => {
+              ev.target.onerror = null;
+              ev.target.src = defaultTokenImage;
+            }}
+          />
+        ) : (
+          <img alt={token.symbol} src={defaultTokenImage} />
+        )}
       </div>
       <div className='token_name'>
         {token && token.name ? (
@@ -62,6 +63,7 @@ TokenCard.propTypes = {
   decimals: PropTypes.number.isRequired,
   defaultTokenImage: PropTypes.string,
   token: PropTypes.shape({
+    logo: PropTypes.string,
     name: PropTypes.string,
     symbol: PropTypes.string
   })

--- a/packages/fether-ui/src/TokenCard/TokenCard.js
+++ b/packages/fether-ui/src/TokenCard/TokenCard.js
@@ -21,18 +21,17 @@ export const TokenCard = ({
   <Card {...otherProps}>
     <div className='token'>
       <div className='token_icon'>
-        {!!token && !!token.logo ? (
-          <img
-            alt={token.symbol}
-            src={token.logo}
-            onError={ev => {
-              ev.target.onerror = null;
-              ev.target.src = defaultTokenImage;
-            }}
-          />
-        ) : (
-          <img alt={token.symbol} src={defaultTokenImage} />
-        )}
+        <img
+          alt={token.symbol}
+          src={
+            (!!token.logo && token.logo) ||
+            `https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/${token.symbol.toLowerCase()}%402x.png`
+          }
+          onError={ev => {
+            ev.target.onerror = null;
+            ev.target.src = defaultTokenImage;
+          }}
+        />
       </div>
       <div className='token_name'>
         {token && token.name ? (
@@ -63,7 +62,6 @@ TokenCard.propTypes = {
   decimals: PropTypes.number.isRequired,
   defaultTokenImage: PropTypes.string,
   token: PropTypes.shape({
-    logo: PropTypes.string,
     name: PropTypes.string,
     symbol: PropTypes.string
   })

--- a/scripts/updateTokens/update-tokens-utils.ts
+++ b/scripts/updateTokens/update-tokens-utils.ts
@@ -168,11 +168,9 @@ function renameSymbolCollisions(
   }, renamedTokens);
 }
 
-async function addLogo(
-  token: NormalizedTokenJSON
-): Promise<NormalizedTokenJSON> {
+async function addLogo(token: NormalizedTokenJSON): NormalizedTokenJSON {
   const { symbol } = token;
-  const fetchUrl = `https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/${symbol.toLocaleLowerCase()}%402x.png`;
+  const fetchUrl = `https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/${symbol.toLowerCase()}%402x.png`;
 
   return await fetch(fetchUrl).then(res => {
     if (res.ok) {

--- a/scripts/updateTokens/update-tokens-utils.ts
+++ b/scripts/updateTokens/update-tokens-utils.ts
@@ -182,7 +182,7 @@ async function addLogo(
       }
       return token;
     })
-    .catch(error => console.error("Error:", error));
+    .catch(() => console.error(`Error: Could not fetch ${fetchUrl}`));
 
   return tokenResult;
 }

--- a/scripts/updateTokens/update-tokens-utils.ts
+++ b/scripts/updateTokens/update-tokens-utils.ts
@@ -1,3 +1,5 @@
+import fetch from "node-fetch";
+
 import {
   RawTokenJSON,
   ValidatedTokenJSON,
@@ -30,7 +32,9 @@ const networks = [
 function processTokenJson(tokensJson: RawTokenJSON[]): Token[] {
   const normalizedTokens = tokensJson
     .map(validateTokenJSON)
-    .map(normalizeTokenJSON);
+    .map(normalizeTokenJSON)
+    .map(addLogo);
+
   checkForDuplicateAddresses(normalizedTokens);
   return handleDuplicateSymbols(normalizedTokens);
 }
@@ -162,6 +166,24 @@ function renameSymbolCollisions(
     );
     return [...prev, tokenToInsert];
   }, renamedTokens);
+}
+
+async function addLogo(
+  token: NormalizedTokenJSON
+): Promise<NormalizedTokenJSON> {
+  const { symbol } = token;
+  const fetchUrl = `https://raw.githubusercontent.com/atomiclabs/cryptocurrency-icons/master/32%402x/color/${symbol.toLocaleLowerCase()}%402x.png`;
+
+  return await fetch(fetchUrl).then(res => {
+    if (res.ok) {
+      return {
+        logo: fetchUrl,
+        ...token
+      };
+    } else {
+      return token;
+    }
+  });
 }
 
 export { networks, processTokenJson };

--- a/scripts/updateTokens/update-tokens-utils.ts
+++ b/scripts/updateTokens/update-tokens-utils.ts
@@ -182,7 +182,7 @@ async function addLogo(
       }
       return token;
     })
-    .catch(() => console.error(`Error: Could not fetch ${fetchUrl}`));
+    .catch(() => console.log(`Error: Could not fetch ${fetchUrl}`));
 
   return tokenResult;
 }

--- a/scripts/updateTokens/update-tokens.ts
+++ b/scripts/updateTokens/update-tokens.ts
@@ -10,6 +10,8 @@ import * as path from "path";
 const hardcoded_ipfs_files = {
   eth:
     "https://cloudflare-ipfs.com/ipfs/QmUJJpSQXWiKh6Jex6wLSZ1RWND8CxJu6XQMb7v2ByQhTR",
+  gor:
+    "https://cloudflare-ipfs.com/ipfs/QmYznKJJK52BaLkQVJnzeaJNf8U4QAFkFXd2PGVaT29otW",
   kov:
     "https://cloudflare-ipfs.com/ipfs/QmZUXkAH69BpjJWcpND5HnQVsro6CXVxKiSX9vK49KsyZn",
   rop:
@@ -127,7 +129,7 @@ async function run() {
               "Failed to write tokens json to file, see above error"
             );
           }
-          console.log("Succesfully imported", tokens.length, " tokens!");
+          console.log("Succesfully imported", tokens.length, "tokens!");
         }
       );
     } else {

--- a/scripts/updateTokens/update-tokens.ts
+++ b/scripts/updateTokens/update-tokens.ts
@@ -8,12 +8,12 @@ import { networks, processTokenJson } from "./update-tokens-utils";
 import * as path from "path";
 
 const hardcoded_ipfs_files = {
-  eth:
-    "https://cloudflare-ipfs.com/ipfs/QmUJJpSQXWiKh6Jex6wLSZ1RWND8CxJu6XQMb7v2ByQhTR",
+  //  eth:
+  //    "https://cloudflare-ipfs.com/ipfs/QmUJJpSQXWiKh6Jex6wLSZ1RWND8CxJu6XQMb7v2ByQhTR",
   kov:
-    "https://cloudflare-ipfs.com/ipfs/QmZUXkAH69BpjJWcpND5HnQVsro6CXVxKiSX9vK49KsyZn",
-  rop:
-    "https://cloudflare-ipfs.com/ipfs/QmRAzyMEFNFFRqKTMcpk5qDdTpctgTDQU2PN8RPXSt5guj"
+    "https://cloudflare-ipfs.com/ipfs/QmZUXkAH69BpjJWcpND5HnQVsro6CXVxKiSX9vK49KsyZn"
+  //  rop:
+  //    "https://cloudflare-ipfs.com/ipfs/QmRAzyMEFNFFRqKTMcpk5qDdTpctgTDQU2PN8RPXSt5guj"
 };
 
 function httpsGet(opts: any): Promise<string> {

--- a/scripts/updateTokens/update-tokens.ts
+++ b/scripts/updateTokens/update-tokens.ts
@@ -8,12 +8,12 @@ import { networks, processTokenJson } from "./update-tokens-utils";
 import * as path from "path";
 
 const hardcoded_ipfs_files = {
-  //  eth:
-  //    "https://cloudflare-ipfs.com/ipfs/QmUJJpSQXWiKh6Jex6wLSZ1RWND8CxJu6XQMb7v2ByQhTR",
+  eth:
+    "https://cloudflare-ipfs.com/ipfs/QmUJJpSQXWiKh6Jex6wLSZ1RWND8CxJu6XQMb7v2ByQhTR",
   kov:
-    "https://cloudflare-ipfs.com/ipfs/QmZUXkAH69BpjJWcpND5HnQVsro6CXVxKiSX9vK49KsyZn"
-  //  rop:
-  //    "https://cloudflare-ipfs.com/ipfs/QmRAzyMEFNFFRqKTMcpk5qDdTpctgTDQU2PN8RPXSt5guj"
+    "https://cloudflare-ipfs.com/ipfs/QmZUXkAH69BpjJWcpND5HnQVsro6CXVxKiSX9vK49KsyZn",
+  rop:
+    "https://cloudflare-ipfs.com/ipfs/QmRAzyMEFNFFRqKTMcpk5qDdTpctgTDQU2PN8RPXSt5guj"
 };
 
 function httpsGet(opts: any): Promise<string> {
@@ -103,7 +103,7 @@ async function run() {
       const tokensJson: RawTokenJSON[] = JSON.parse(await httpsGet(tokensUrl));
 
       // Format the json to match our format in /packages/fether-react/src/assets/tokens/<network>.json
-      const tokens = processTokenJson(tokensJson);
+      const tokens = await processTokenJson(tokensJson);
       // Write to the file
       console.log(
         `Writing Tokens JSON to /packages/fether-react/src/assets/tokens/${
@@ -127,7 +127,7 @@ async function run() {
               "Failed to write tokens json to file, see above error"
             );
           }
-          console.log("Succesfully imported", tokens.length, "tokens!");
+          console.log("Succesfully imported", tokens.length, " tokens!");
         }
       );
     } else {


### PR DESCRIPTION
Because the security PR (https://github.com/paritytech/fether/pull/451) will prevent Fether from fetching random urls, we need to have one source for ERC-20 icons. I chose https://github.com/atomiclabs/cryptocurrency-icons/ github repo.

- Sadly ThibCoin and GavCoin have no face anymore, but most crypto have.

Here is an example with a mainnet random account:
```
localStorage.setItem("localforage/__paritylight::paritySignerAccounts", '[{"address":"0x564286362092D8e7936f0549571a803B203aAceD","name":"Random","chainId":1}]');
```

![image](https://user-images.githubusercontent.com/33178835/55406464-75031800-555c-11e9-82c2-b9264a07298e.png)
