### PR TITLE
refactor: Update craco and remove --react-scripts workaround

### DIFF
--- a/packages/fether-react/craco.config.js
+++ b/packages/fether-react/craco.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   babel: {
     plugins: [['@babel/plugin-proposal-decorators', { legacy: true }]]
-  }
+  },
+  // craco isn't compatible with monorepos by default
+  reactScriptsPath: '../../node_modules/react-scripts'
 };

--- a/packages/fether-react/package.json
+++ b/packages/fether-react/package.json
@@ -27,14 +27,14 @@
   "scripts": {
     "build": "npm-run-all build-*",
     "build-css": "node-sass-chokidar src/ -o src/",
-    "build-js": "cross-env SKIP_PREFLIGHT_CHECK=true craco build --react-scripts ../../node_modules/react-scripts",
+    "build-js": "cross-env SKIP_PREFLIGHT_CHECK=true craco build",
     "start": "npm-run-all -p start-*",
     "start-css": "npm run build-css -- --watch --recursive",
-    "start-js": "cross-env SKIP_PREFLIGHT_CHECK=true BROWSER=none craco start --react-scripts ../../node_modules/react-scripts",
-    "test": "ln -s ../../../node_modules/react-scripts node_modules/ && cross-env SKIP_PREFLIGHT_CHECK=true craco test; EXIT_CODE=$?; rm node_modules/react-scripts; exit $EXIT_CODE"
+    "start-js": "cross-env SKIP_PREFLIGHT_CHECK=true BROWSER=none craco start",
+    "test": "cross-env SKIP_PREFLIGHT_CHECK=true craco test"
   },
   "dependencies": {
-    "@craco/craco": "^3.3.1",
+    "@craco/craco": "^4.0.0",
     "@parity/abi": "^5.1.1",
     "@parity/api": "^5.1.1",
     "@parity/contracts": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,10 +953,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@craco/craco@^3.3.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-3.4.1.tgz#a65e29d7cb661e09e68269ba09ade39d174ec359"
-  integrity sha512-PVuDx5iLzoYeFrjNUVbblQCGzFyw/DoBBHFI4+JlSCvgEkp07jbBm5fe+z/MqzYJUQm1bFbxe6qbQWI5LFl6XA==
+"@craco/craco@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-4.0.0.tgz#9baabdc4bd4e156c3dbda647f5bf19b4cfc991ae"
+  integrity sha512-YWBywRU77lLLEW2Ue3TqYjthOxknz1/Ah7GyfAEILBcueZm0sfKaLbAxP9AfYdLSNOff0InvWnmOpu5yFGml9w==
   dependencies:
     cross-spawn "6.0.5"
     lodash.mergewith "4.6.1"


### PR DESCRIPTION
Update craco dependency and remove a workaround we had to use to fix `craco test` not taking `--react-scripts` into account (bug was fixed in the latest version of craco, https://github.com/sharegate/craco/issues/2)