### PR TITLE
chore: Allow fetching cross-platform parity-ethereum

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,11 +10,10 @@ variables:
   CARGOFLAGS: ''
 
 cache:
-  key: "${CI_JOB_NAME}"
+  key: '${CI_JOB_NAME}'
   paths:
     - node_modules/
     - packages/*/node_modules/
-
 
 .branches: &branches
   only:
@@ -79,6 +78,9 @@ win-build:
   script:
     - yarn install
     - yarn build
+    # `win-build` is a linux machine, so it downloaded a linux parity-ethereum.
+    # We download a windows one to make it cross-compile for windows.
+    - rm packages/fether-electron/static/parity* && yarn fetch-parity --win
     - yarn release --win
   tags:
     - linux-docker

--- a/package.json
+++ b/package.json
@@ -42,10 +42,11 @@
     "yarn": "^1.4.2"
   },
   "scripts": {
-    "postinstall": "cd scripts && node ./fetch-latest-parity.js",
+    "postinstall": "yarn fetch-parity",
     "build": "lerna run build",
     "preelectron": "yarn build",
     "electron": "cd packages/fether-electron && yarn electron",
+    "fetch-parity": "cd scripts && node ./fetch-latest-parity.js",
     "lint-files": "./scripts/lint-files.sh '**/*.js'",
     "lint": "yarn lint-files",
     "prepackage": "yarn build",

--- a/scripts/fetch-latest-parity.js
+++ b/scripts/fetch-latest-parity.js
@@ -57,6 +57,11 @@ if (foundPath) {
   // Bundled Parity was found, we check if the version matches the minimum requirements
   getBinaryVersion(foundPath)
     .then(version => {
+      if (!version) {
+        console.log("Couldn't get bundled Parity Ethereum version.");
+        return downloadParity();
+      }
+
       if (!semver.satisfies(version, versionRequirement)) {
         console.log(
           'Bundled Parity Ethereum %s is older than required version %s',
@@ -146,14 +151,19 @@ function downloadParity () {
       })
       .then(getBinaryVersion)
       .then(bundledVersion =>
-        console.log(`Success: bundled Parity Ethereum ${bundledVersion}`)
+        console.log(
+          `Success: bundled Parity Ethereum ${bundledVersion ||
+            "(couldn't get version)"}`
+        )
       )
   );
 }
 
 function getBinaryVersion (binaryPath) {
-  return exec(`${binaryPath} --version`).then(({ stdout, stderr }) => {
-    if (stderr) throw new Error(stderr);
-    return stdout.match(/v\d+\.\d+\.\d+/)[0];
-  });
+  return exec(`${binaryPath} --version`)
+    .then(({ stdout, stderr }) => {
+      if (stderr) throw new Error(stderr);
+      return stdout.match(/v\d+\.\d+\.\d+/)[0];
+    })
+    .catch(error => console.warn(error.message));
 }

--- a/scripts/fetch-latest-parity.js
+++ b/scripts/fetch-latest-parity.js
@@ -18,19 +18,28 @@ const exec = promisify(require('child_process').exec);
 const fsChmod = promisify(chmod);
 const fsWriteFile = promisify(writeFile);
 
-let os;
-switch (process.platform) {
-  case 'win32':
-    os = 'windows';
-    break;
-  case 'darwin':
-    os = 'darwin';
-    break;
-  default:
-    os = 'linux';
+function getOs () {
+  if (process.argv.includes('--win')) {
+    return 'windows';
+  }
+  if (process.argv.includes('--mac')) {
+    return 'darwin';
+  }
+  if (process.argv.includes('--linux')) {
+    return 'linux';
+  }
+
+  switch (process.platform) {
+    case 'win32':
+      return 'windows';
+    case 'darwin':
+      return 'darwin';
+    default:
+      return 'linux';
+  }
 }
 
-const ENDPOINT = `https://vanity-service.parity.io/parity-binaries?os=${os}&architecture=x86_64`;
+const ENDPOINT = `https://vanity-service.parity.io/parity-binaries?os=${getOs()}&architecture=x86_64`;
 
 const STATIC_DIRECTORY = path.join(
   '..',


### PR DESCRIPTION
On gitlab we build the Windows binary on Linux: we need to fetch the windows parity-ethereum from linux.

`yarn fetch-parity --win` or `--mac` or `--linux`