### PR TITLE
fix: Relates to #524. Update Readme build instructions to support Electron 5 sandboxing on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ cd ./fether
 yarn install
 ```
 
+### Configure Sandboxing
+
+#### Linux
+
+```bash
+sudo chown root /path/to/fether/node_modules/electron/dist/chrome-sandbox
+sudo chmod 4755 /path/to/fether/node_modules/electron/dist/chrome-sandbox
+```
+
 ### Build and run
 
 #### Build this repo and run


### PR DESCRIPTION
I've only put these instructions under the heading "Linux" since I encountered the issue when running Debian