### PR TITLE
feat: Send transaction with "data" field and allow amount to be zero

### DIFF
--- a/packages/fether-electron/package.json
+++ b/packages/fether-electron/package.json
@@ -37,7 +37,7 @@
     "package": "electron-builder",
     "prerelease": "./scripts/revertElectronBug.sh",
     "release": "electron-builder",
-    "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev",
+    "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev --chain goerli",
     "test": "jest --all --color --coverage"
   },
   "dependencies": {

--- a/packages/fether-electron/package.json
+++ b/packages/fether-electron/package.json
@@ -37,7 +37,7 @@
     "package": "electron-builder",
     "prerelease": "./scripts/revertElectronBug.sh",
     "release": "electron-builder",
-    "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev --chain goerli",
+    "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev",
     "test": "jest --all --color --coverage"
   },
   "dependencies": {

--- a/packages/fether-react/package.json
+++ b/packages/fether-react/package.json
@@ -47,6 +47,7 @@
     "bip39": "^2.5.0",
     "debounce-promise": "^3.1.0",
     "debug": "^4.1.0",
+    "ethjs-util": "^0.1.6",
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^6.0.0",
     "ethereumjs-wallet": "^0.6.2",

--- a/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
+++ b/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
@@ -78,6 +78,7 @@ class SignedTxSummary extends Component {
                   <Form
                     key='txForm'
                     initialValues={{
+                      data: tx.data,
                       from: address,
                       to: tx.to,
                       amount: `${tx.amount} ${token.symbol}`,
@@ -101,6 +102,14 @@ class SignedTxSummary extends Component {
                             disabled
                             label={i18n.t(`${packageNS}:tx.form.field.amount`)}
                             name='amount'
+                            render={FetherForm.Field}
+                          />
+
+                          <Field
+                            className='form_field_value'
+                            disabled
+                            label={i18n.t(`${packageNS}:tx.form.field.data`)}
+                            name='data'
                             render={FetherForm.Field}
                           />
 

--- a/packages/fether-react/src/Send/TxForm/TxDetails/TxDetails.js
+++ b/packages/fether-react/src/Send/TxForm/TxDetails/TxDetails.js
@@ -17,7 +17,8 @@ class TxDetails extends Component {
     if (
       !estimatedTxFee ||
       !values.gasPrice ||
-      !values.amount ||
+      // Allow estimating tx fee when the amount is zero
+      // !values.amount ||
       !values.chainId ||
       !values.ethBalance ||
       !values.gas ||
@@ -43,6 +44,17 @@ ${this.renderTotalAmount()}`;
     }
 
     const gasPriceBn = new BigNumber(values.gasPrice.toString());
+
+    // Temporarily solution since Fether has to have the simplest UI
+    // a Gas Price form field may be too overwhelming for beginner users
+    // but advanced users may want to send data that may require a
+    // higher Gas Limit. On
+    if (values.data) {
+      return i18n.t(`${packageNS}:tx.form.details.gas_limit`, {
+        gas_limit: new BigNumber(200000)
+      });
+    }
+
     const gasLimitBn = estimatedTxFee
       .div(gasPriceBn)
       .div(10 ** 9)
@@ -76,14 +88,14 @@ ${this.renderTotalAmount()}`;
     const { estimatedTxFee, token, values } = this.props;
     const currentChainIdBN = values.chainId;
 
-    if (!estimatedTxFee || !values.amount || !token.address) {
+    if (!estimatedTxFee || !token.address) {
       return;
     }
 
     const totalAmount = `${fromWei(
       estimatedTxFee.plus(
         isNotErc20TokenAddress(token.address)
-          ? toWei(values.amount.toString())
+          ? values.amount && toWei(values.amount.toString())
           : 0
       ),
       'ether'

--- a/packages/fether-react/src/Send/TxForm/TxDetails/TxDetails.js
+++ b/packages/fether-react/src/Send/TxForm/TxDetails/TxDetails.js
@@ -9,6 +9,7 @@ import { fromWei, toWei } from '@parity/api/lib/util/wei';
 
 import i18n, { packageNS } from '../../../i18n';
 import { chainIdToString, isNotErc20TokenAddress } from '../../../utils/chain';
+import { GAS_LIMIT_DATA } from '../../../utils/transaction';
 
 class TxDetails extends Component {
   renderDetails = () => {
@@ -51,7 +52,7 @@ ${this.renderTotalAmount()}`;
     // higher Gas Limit. On
     if (values.data) {
       return i18n.t(`${packageNS}:tx.form.details.gas_limit`, {
-        gas_limit: new BigNumber(200000)
+        gas_limit: GAS_LIMIT_DATA
       });
     }
 

--- a/packages/fether-react/src/Send/Unlock/Unlock.js
+++ b/packages/fether-react/src/Send/Unlock/Unlock.js
@@ -95,6 +95,14 @@ class Unlock extends Component {
                       defaultValue={`${tx.amount} ${token.symbol}`}
                       label={i18n.t(`${packageNS}:tx.form.field.amount`)}
                     />
+
+                    <FetherForm.Field
+                      as='textarea'
+                      className='form_field_value'
+                      disabled
+                      defaultValue={`${tx.data}`}
+                      label={i18n.t(`${packageNS}:tx.form.field.data`)}
+                    />
                   </div>,
                   <Form
                     key='signerForm'

--- a/packages/fether-react/src/i18n/locales/de.json
+++ b/packages/fether-react/src/i18n/locales/de.json
@@ -139,6 +139,7 @@
       "label_unlock": "Konto entsperren:",
       "field": {
         "to": "Zu",
+        "data": "Daten",
         "amount": "Menge",
         "tx_speed": "Transaktionsgeschwindigkeit",
         "high": "Hoch",
@@ -160,6 +161,7 @@
       },
       "validation": {
         "amount_invalid": "Bitte geben Sie einen gültigen Betrag ein",
+        "data_invalid": "Bitte geben Sie eine gültige hex Eingabedatenfolge ein",
         "eth_balance_too_low_for_gas": "{{chain_id}}-Bilanz zu niedrig, um für Gas zu zahlen.",
         "eth_balance_too_low": "Sie haben nicht genug {{chain_id}}-Balance",
         "fetching_chain_id": "Abrufen der Ketten-ID",

--- a/packages/fether-react/src/i18n/locales/en.json
+++ b/packages/fether-react/src/i18n/locales/en.json
@@ -139,6 +139,7 @@
       "label_unlock": "Unlock account:",
       "field": {
         "to": "To",
+        "data": "Data",
         "amount": "Amount",
         "tx_speed": "Transaction Speed",
         "high": "High",
@@ -160,6 +161,7 @@
       },
       "validation": {
         "amount_invalid": "Please enter a valid amount",
+        "data_invalid": "Please enter a valid input data hex string",
         "eth_balance_too_low_for_gas": "{{chain_id}} balance too low to pay for gas.",
         "eth_balance_too_low": "You don't have enough {{chain_id}} balance",
         "fetching_chain_id": "Fetching chain ID",

--- a/packages/fether-react/src/utils/blockscout.js
+++ b/packages/fether-react/src/utils/blockscout.js
@@ -20,6 +20,7 @@ const baseUrlForChain = chainName => {
       chainNameBlockscout = 'mainnet';
       baseUrl = `https://blockscout.com/etc/${chainNameBlockscout}`;
       break;
+    case 'goerli':
     case 'kovan':
     case 'ropsten':
       chainNameBlockscout = chainName;

--- a/packages/fether-react/src/utils/transaction.js
+++ b/packages/fether-react/src/utils/transaction.js
@@ -18,6 +18,7 @@ import EthereumTx from 'ethereumjs-tx';
 
 const debug = Debug('transaction');
 const GAS_MULT_FACTOR = 1.25; // Since estimateGas is not always accurate, we add a 25% factor for buffer.
+export const GAS_LIMIT_DATA = new BigNumber(150000);
 
 export const contractForToken = memoize(tokenAddress =>
   makeContract(tokenAddress, abi)
@@ -100,7 +101,7 @@ export const txForErc20 = (tx, token) => {
   };
 
   if (tx.gas) {
-    output.options.gas = tx.gas;
+    output.options.gas = tx.data ? GAS_LIMIT_DATA : tx.gas;
   }
 
   return output;
@@ -120,7 +121,7 @@ export const txForEth = tx => {
   };
   // gas field should not be present when the function is called for gas estimation.
   if (tx.gas) {
-    output.gas = tx.gas;
+    output.gas = tx.data ? GAS_LIMIT_DATA : tx.gas;
   }
   return output;
 };
@@ -141,9 +142,12 @@ const getEthereumTx = tx => {
     transactionCount
   } = tx;
 
+  // Temporary solution
+  const gasLimit = data ? GAS_LIMIT_DATA : gas;
+
   const txParams = {
     nonce: '0x' + transactionCount.toNumber().toString(16),
-    gasLimit: '0x' + gas.toNumber().toString(16),
+    gasLimit: '0x' + gasLimit.toNumber().toString(16),
     gasPrice: toWei(gasPrice, 'shannon').toNumber(),
     chainId
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6158,7 +6158,7 @@ ethereumjs-wallet@^0.6.2:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3:
+ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==


### PR DESCRIPTION
* [x] - Allows DOT holders to map Ethereum-DOT into ChainX-SDOT and get the PCX airdrop (see https://github.com/chainx-org/ChainX/issues/66) by sending a transaction with a "data" field value (their ChainX Address converted to hex) 
  * Update Send transaction UI so "amount" field can be 0, since some users may want to just send some data (i.e. https://github.com/chainx-org/ChainX/issues/66)
  * Set the default amount value to be 0 and not required
  * Update Send transaction UI to support "data" field in hex (with 0x prefix)
  * Use a hard-coded Gas Limit of 200,000 when user provides hex "data" value
  * Remove logic that doesn't make sense (i.e. `else if (amountBn.isZero()) {`)
  * Update validation messages
  * Add support for Blockscout link when user using Goerli testnet
  * Update internationalisation
  * Use custom `isHexString` function instead of the ethereumjs-util's version. The ethereumjs-util's version is used by MyCrypto and doesn't work properly.
  * Tested on Goerli testnet by creating two accounts, requesting Goerli tokens, running with `--chain goerli` appended to the end (so you'll have to remove this if you want to use mainnet) otherwise it uses mainnet by default (i.e. `"start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev --chain goerli",` in fether/packages/fether-electron/package.json), and sending a transaction with the high gas price, the hex data. For example, for ChainX convert your ChainX Address (UTF8 chars) into Hex code (i.e. for example if your ChainX Address was "0xhelloworld" then remove the "0x" prefix, then copy/paste the remainder at https://www.browserling.com/tools/utf8-to-hex, so "helloworld" becomes => `\x68\x65\x6c\x6c\x6f\x20\x77\x6f\x72\x6c\x64`, then remove the `\x`'s, => `68656c6c6f20776f726c64` => then prepend 0x => `0x68656c6c6f20776f726c64` and add that as the "data" field value... p.s. there are less ugly ways to do this but i'll let others figure that out), then send the transaction, and when the transaction is successful go to the Blockscout link and you'll see under "Raw Input" ("Input Data" on Etherscan) that you can switch between viewing it in UTF8 or Hex, i.e. https://blockscout.com/eth/goerli/tx/0x7eaec61ce7753fd4c80aec4509c49942b53986585e4864e18134806bffb25f10/internal_transactions)
 * Verified that was able to get "Transaction ID binding complete" status on ChainX confirming that sending an Ethereum transaction using Fether from a DOT holder address to any other Ethereum account with 0 ETH and a "data" value containing the hex version of the ChainX Address works on mainnet
* [ ] Fix it so that it doesn't error when an invalid amount is entered

Note: To use this PR in development prior to it being merged into master, run `git fetch origin luke-data-field:luke-data-field; git checkout luke-data-field; yarn; yarn start` you may first need to follow the steps in this PR https://github.com/paritytech/fether/pull/525 before running the `yarn; yarn start` step. if you can't sync with the chain, then try removing the chain from the relevant directory of your OS and resyncing from scratch, see https://wiki.parity.io/Fether-FAQ#where-is-the-light-client-blockchain-database-used-by-fether-stored
* Note: I've left `--chain goerli` in the PR since users might want to play around using Goerli testnet first

**Important Note** I've put this on-ice since it's unlikely anyone else wants to use it other than me, and it's highly unlikely that it'll ever get merged. I'm also trying to focus on Rust. The only reason I've published this is because I needed this functionality to use ChainX and I thought I may as well share the code to help other ChainX users. It's also unlikely that I'll update Parity Signer to show the "data" field value (if it doesn't already) since it's not necessary, so this can be left for the community.