### PR TITLE
feat: Add timeout on confirmation screens

### DIFF
--- a/packages/fether-react/package.json
+++ b/packages/fether-react/package.json
@@ -66,6 +66,7 @@
     "react-final-form": "^3.6.4",
     "react-final-form-listeners": "^1.0.1",
     "react-i18next": "^10.2.0",
+    "react-idle-timer": "^4.2.9",
     "react-markdown": "^3.3.4",
     "react-resize-detector": "^3.0.1",
     "react-router-dom": "^4.2.2",

--- a/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
+++ b/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { Field, Form } from 'react-final-form';
 import { Form as FetherForm, Header } from 'fether-ui';
 import { inject, observer } from 'mobx-react';
+import IdleTimer from 'react-idle-timer';
 import { Link } from 'react-router-dom';
 import { withProps } from 'recompose';
 
@@ -46,12 +47,15 @@ class SignedTxSummary extends Component {
   render () {
     const {
       account: { address },
+      history,
       sendStore: { tx },
       token
     } = this.props;
 
     return (
       <div>
+        <IdleTimer onIdle={() => history.go(-3)} timeout={1000 * 60} />
+
         <Header
           left={
             <Link to={`/tokens/${address}`} className='icon -back'>

--- a/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
+++ b/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
@@ -28,7 +28,9 @@ import withTokens from '../../utils/withTokens';
 @withEthBalance // ETH or ETC balance
 @observer
 class SignedTxSummary extends Component {
-  handleGoToTxForm = () => history.go(-3);
+  handleGoToTxForm = () => {
+    this.props.history.go(-3);
+  };
 
   handleSubmit = values => {
     const {
@@ -49,7 +51,6 @@ class SignedTxSummary extends Component {
   render () {
     const {
       account: { address },
-      history,
       sendStore: { tx },
       token
     } = this.props;

--- a/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
+++ b/packages/fether-react/src/Send/SignedTxSummary/SignedTxSummary.js
@@ -28,6 +28,8 @@ import withTokens from '../../utils/withTokens';
 @withEthBalance // ETH or ETC balance
 @observer
 class SignedTxSummary extends Component {
+  handleGoToTxForm = () => history.go(-3);
+
   handleSubmit = values => {
     const {
       account: { address },
@@ -54,7 +56,7 @@ class SignedTxSummary extends Component {
 
     return (
       <div>
-        <IdleTimer onIdle={() => history.go(-3)} timeout={1000 * 60} />
+        <IdleTimer onIdle={this.handleGoToTxForm} timeout={1000 * 60} />
 
         <Header
           left={

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -207,7 +207,6 @@ class TxForm extends Component {
       account: { address, type },
       chainId,
       ethBalance,
-      history,
       sendStore: { tx },
       token,
       transactionCount

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -16,7 +16,6 @@ import { isAddress } from '@parity/api/lib/util/address';
 import light from '@parity/light.js-react';
 import { Link } from 'react-router-dom';
 import { OnChange } from 'react-final-form-listeners';
-import IdleTimer from 'react-idle-timer';
 import { withProps } from 'recompose';
 import { startWith } from 'rxjs/operators';
 
@@ -218,7 +217,6 @@ class TxForm extends Component {
 
     return (
       <div>
-        <IdleTimer onIdle={() => history.goBack()} timeout={1000 * 60} />
         <Header
           left={
             <Link to={`/tokens/${address}`} className='icon -back'>

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -16,8 +16,9 @@ import { isAddress } from '@parity/api/lib/util/address';
 import light from '@parity/light.js-react';
 import { Link } from 'react-router-dom';
 import { OnChange } from 'react-final-form-listeners';
-import { startWith } from 'rxjs/operators';
+import IdleTimer from 'react-idle-timer';
 import { withProps } from 'recompose';
+import { startWith } from 'rxjs/operators';
 
 import i18n, { packageNS } from '../../i18n';
 import Debug from '../../utils/debug';
@@ -207,6 +208,7 @@ class TxForm extends Component {
       account: { address, type },
       chainId,
       ethBalance,
+      history,
       sendStore: { tx },
       token,
       transactionCount
@@ -216,6 +218,7 @@ class TxForm extends Component {
 
     return (
       <div>
+        <IdleTimer onIdle={() => history.goBack()} timeout={1000 * 60} />
         <Header
           left={
             <Link to={`/tokens/${address}`} className='icon -back'>

--- a/packages/fether-react/src/Send/TxForm/TxForm.js
+++ b/packages/fether-react/src/Send/TxForm/TxForm.js
@@ -16,8 +16,8 @@ import { isAddress } from '@parity/api/lib/util/address';
 import light from '@parity/light.js-react';
 import { Link } from 'react-router-dom';
 import { OnChange } from 'react-final-form-listeners';
-import { withProps } from 'recompose';
 import { startWith } from 'rxjs/operators';
+import { withProps } from 'recompose';
 
 import i18n, { packageNS } from '../../i18n';
 import Debug from '../../utils/debug';

--- a/packages/fether-react/src/Send/Unlock/Unlock.js
+++ b/packages/fether-react/src/Send/Unlock/Unlock.js
@@ -58,7 +58,7 @@ class Unlock extends Component {
 
     return (
       <div>
-        <IdleTimer onIdle={() => history.goBack()} timeout={1000 * 10} />
+        <IdleTimer onIdle={() => history.goBack()} timeout={1000 * 60} />
 
         <Header
           left={

--- a/packages/fether-react/src/Send/Unlock/Unlock.js
+++ b/packages/fether-react/src/Send/Unlock/Unlock.js
@@ -58,7 +58,7 @@ class Unlock extends Component {
 
     return (
       <div>
-        <IdleTimer onIdle={() => history.goBack()} timeout={1000 * 60} />
+        <IdleTimer onIdle={history.goBack} timeout={1000 * 60} />
 
         <Header
           left={

--- a/packages/fether-react/src/Send/Unlock/Unlock.js
+++ b/packages/fether-react/src/Send/Unlock/Unlock.js
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { Field, Form } from 'react-final-form';
 import { Form as FetherForm, Header } from 'fether-ui';
 import { inject, observer } from 'mobx-react';
+import IdleTimer from 'react-idle-timer';
 import { Link, Redirect } from 'react-router-dom';
 import { withProps } from 'recompose';
 
@@ -57,6 +58,8 @@ class Unlock extends Component {
 
     return (
       <div>
+        <IdleTimer onIdle={() => history.goBack()} timeout={1000 * 10} />
+
         <Header
           left={
             <Link to={`/tokens/${address}`} className='icon -back'>
@@ -73,7 +76,6 @@ class Unlock extends Component {
             )
           }
         />
-
         <RequireHealthOverlay require='sync'>
           <div className='window_content'>
             <div className='box -padded'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12720,6 +12720,11 @@ react-i18next@^10.2.0:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
+react-idle-timer@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-4.2.9.tgz#9054dc508953521e76fd5255f692ec8a816c304c"
+  integrity sha512-Bj1SaHdCS+YiWgASgmZtr5MEWfsyIg9AWGdpSKbrzlsjpEXYuCe1dsuAetY0ES81w3sz98oUBBj25T4Hl7JXqg==
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"


### PR DESCRIPTION
fixes #537 

Repro:
- send tx
- on confirm screen, be idle for 1min

Expected: should go back to TxForm screen.

Note: Added on password unlock and Parity signer confirm screens.