### PR TITLE
fix: Disable Electron remote module

### DIFF
--- a/packages/fether-electron/src/main/app/options/config/index.js
+++ b/packages/fether-electron/src/main/app/options/config/index.js
@@ -144,6 +144,10 @@ const SECURITY_OPTIONS = {
      */
     devTools: !IS_PROD,
     /**
+     * Disable Electron's remote module.
+     */
+    enableRemoteModule: false,
+    /**
      * `nodeIntegration` when enabled allows the software to use Electron's APIs
      * and gain access to Node.js. It must be disabled to restricting access to
      * Node.js global symbols like `require` from global scope and requires the

--- a/packages/fether-electron/src/main/app/options/config/index.js
+++ b/packages/fether-electron/src/main/app/options/config/index.js
@@ -177,7 +177,6 @@ const SECURITY_OPTIONS = {
      * Reference: https://doyensec.com/resources/us-17-Carettoni-Electronegativity-A-Study-Of-Electron-Security-wp.pdf
      */
     sandbox: true, // Do not set to false. Run electron with `electron --enable-sandbox` to sandbox all BrowserWindow instances
-    enableRemoteModule: true, // Remote is required in fether-react parityStore.js
     // Enables same origin policy to prevent execution of insecure code. Do not set to false
     webSecurity: true,
     allowRunningInsecureContent: false, // Do not set to true

--- a/packages/fether-electron/static/preload.js
+++ b/packages/fether-electron/static/preload.js
@@ -17,10 +17,10 @@
  * https://github.com/electron/electron/issues/13130
  */
 
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer } = require('electron');
 
 const RENDERER_ORIGIN =
-  remote.getGlobal('IS_PROD') === true ? 'file://' : 'http://localhost:3000';
+  process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'file://';
 
 /**
  * Handler that receives an IPC message from the main process, and passes it


### PR DESCRIPTION
closes #548 

The issue describes filtering permissions in the `remote` module (point 16 in https://electronjs.org/docs/tutorial/security#16-filter-the-remote-module).

Instead, I did the more drastic point 15: remove altogether the `remote` module.

I would appreciate `yarn start` and `yarn electron` testing, they pass on my computer.