### PR TITLE
fix duplicate account names 

### DIFF
--- a/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
@@ -117,17 +117,14 @@ class AccountName extends Component {
       createAccountStore: { address, name },
       error,
       history,
-      location: { pathname }
+      location: { pathname },
+      accountsInfo
     } = this.props;
-    const currentStep = pathname.slice(-1);
-    const { accountsInfo } = this.props;
 
-    let accountNameExists = false;
-    Object.keys(accountsInfo).forEach(account => {
-      if (accountsInfo[account].name === name) {
-        accountNameExists = true;
-      }
-    });
+    const currentStep = pathname.slice(-1);
+    const accountNameExists = !!Object.values(accountsInfo).find(
+      info => info.name === name
+    );
 
     return (
       <form key='createAccount' noValidate onSubmit={this.handleSubmit}>
@@ -143,6 +140,11 @@ class AccountName extends Component {
           value={name}
         />
         {error && <p>{error}</p>}
+        {accountNameExists && (
+          <p>
+            {i18n.t(`${packageNS}:account.create.error_msg_duplicate_name`)}
+          </p>
+        )}
         <nav className='form-nav -space-around'>
           {currentStep > 1 && (
             <button

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
@@ -10,7 +10,9 @@ import { inject, observer } from 'mobx-react';
 
 import i18n, { packageNS } from '../../../i18n';
 import loading from '../../../assets/img/icons/loading.svg';
+import withAccountsInfo from '../../../utils/withAccountsInfo';
 
+@withAccountsInfo
 @inject('createAccountStore')
 @observer
 class AccountName extends Component {
@@ -118,6 +120,14 @@ class AccountName extends Component {
       location: { pathname }
     } = this.props;
     const currentStep = pathname.slice(-1);
+    const { accountsInfo } = this.props;
+
+    let accountNameExists = false;
+    Object.keys(accountsInfo).forEach(account => {
+      if (accountsInfo[account].name === name) {
+        accountNameExists = true;
+      }
+    });
 
     return (
       <form key='createAccount' noValidate onSubmit={this.handleSubmit}>
@@ -143,7 +153,7 @@ class AccountName extends Component {
               {i18n.t(`${packageNS}:navigation.back`)}
             </button>
           )}
-          {name && address ? (
+          {name && address && !accountNameExists ? (
             <button className='button'>
               {i18n.t(`${packageNS}:navigation.next`)}
             </button>

--- a/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
+++ b/packages/fether-react/src/Accounts/CreateAccount/AccountName/AccountName.js
@@ -123,7 +123,7 @@ class AccountName extends Component {
 
     const currentStep = pathname.slice(-1);
     const accountNameExists = !!Object.values(accountsInfo).find(
-      info => info.name === name
+      info => info.name.toLowerCase() === name.toLowerCase()
     );
 
     return (

--- a/packages/fether-react/src/i18n/locales/de.json
+++ b/packages/fether-react/src/i18n/locales/de.json
@@ -5,6 +5,7 @@
       "label_name_msg": "Bitte geben Sie diesem Konto einen Namen:",
       "label_name": "Name",
       "title": "Ein neues Konto erstellen",
+      "error_msg_duplicate_name": "Ein Konto mit diesem Namen existiert.",
       "copy_phrase": {
         "msg1": "Bitte schreibe deinen geheimen Satz auf ein Blatt Papier:",
         "msg2": "Behalte es sicher und geheim.",

--- a/packages/fether-react/src/i18n/locales/en.json
+++ b/packages/fether-react/src/i18n/locales/en.json
@@ -5,6 +5,7 @@
       "label_name_msg": "Please give this account a name:",
       "label_name": "Name",
       "title": "Create a new account",
+      "error_msg_duplicate_name": "An account already exists with this name.",
       "copy_phrase": {
         "msg1": "Please write your secret phrase on a piece of paper:",
         "msg2": "Keep it secure and secret.",


### PR DESCRIPTION
A simple fix #505. Disables the next button when an account with that name already exists. 