### PR TITLE
fix: CI install node12 for windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,27 +23,16 @@ cache:
     - triggers
     - master
 
-test-node-12:
+linux-test:
   stage: test
-  image: electronuserland/builder:wine
+  image: node:12
   script:
-    # https://askubuntu.com/questions/426750/how-can-i-update-my-nodejs-to-the-latest-version
-    - npm install -g n
-    - n stable
-    - node -v
+    - curl -o- -L https://yarnpkg.com/install.sh | bash
+    - export PATH=$HOME/.yarn/bin:$PATH
+    - yarn install
+    - yarn test
   tags:
     - linux-docker
-
-# linux-test:
-#   stage: test
-#   image: node:12
-#   script:
-#     - curl -o- -L https://yarnpkg.com/install.sh | bash
-#     - export PATH=$HOME/.yarn/bin:$PATH
-#     - yarn install
-#     - yarn test
-#   tags:
-#     - linux-docker
 
 linux-build:
   stage: build
@@ -87,6 +76,10 @@ win-build:
   image: electronuserland/builder:wine
   <<: *branches
   script:
+    # Remove the two next lines once the Docker image gets updated to node 12
+    # https://github.com/electron-userland/electron-builder/issues/4377
+    - npm install -g n
+    - n stable
     - yarn install
     - yarn build
     # `win-build` is a linux machine, so it downloaded a linux parity-ethereum.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,9 @@ test-node-12:
   stage: test
   image: electronuserland/builder:wine
   script:
-    - apt -y install nodejs
+    # https://askubuntu.com/questions/426750/how-can-i-update-my-nodejs-to-the-latest-version
+    - npm install -g n
+    - n stable
     - node -v
   tags:
     - linux-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,13 @@ cache:
     - triggers
     - master
 
+test-node-12:
+  stage: test
+  image: electronuserland/builder:wine
+  script:
+    - apt -y install nodejs
+    - node -v
+
 linux-test:
   stage: test
   image: node:12

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,17 +29,19 @@ test-node-12:
   script:
     - apt -y install nodejs
     - node -v
-
-linux-test:
-  stage: test
-  image: node:12
-  script:
-    - curl -o- -L https://yarnpkg.com/install.sh | bash
-    - export PATH=$HOME/.yarn/bin:$PATH
-    - yarn install
-    - yarn test
   tags:
     - linux-docker
+
+# linux-test:
+#   stage: test
+#   image: node:12
+#   script:
+#     - curl -o- -L https://yarnpkg.com/install.sh | bash
+#     - export PATH=$HOME/.yarn/bin:$PATH
+#     - yarn install
+#     - yarn test
+#   tags:
+#     - linux-docker
 
 linux-build:
   stage: build


### PR DESCRIPTION
Install node 12 on the docker image that builds windows binaries

Attempt to fix https://gitlab.parity.io/parity/fether/-/jobs/260945

Temporary measure until https://github.com/electron-userland/electron-builder/issues/4377 gets merged