### PR TITLE
Force at least the Istanbul release

### DIFF
--- a/packages/fether-electron/package.json
+++ b/packages/fether-electron/package.json
@@ -27,7 +27,7 @@
   ],
   "homepage": "https://github.com/paritytech/fether",
   "parity": {
-    "version": "~2.5.0"
+    "version": "~2.5.10"
   },
   "scripts": {
     "prebuild": "copyfiles -u 2 \"../fether-react/build/**/*\" static/ && ./scripts/fixElectronBug.sh",


### PR DESCRIPTION
This is an insubstantial PR to trigger the CI and get [parity-ethereum v2.5.10](https://github.com/paritytech/parity-ethereum/releases) with Istanbul (coming in ~1 week). We can then release 0.4.1.